### PR TITLE
fix swag bug.

### DIFF
--- a/internal/pkg/api/psping.go
+++ b/internal/pkg/api/psping.go
@@ -23,7 +23,7 @@ type PingResult struct {
 // @Produce json
 // @Param data body PSPingParam true "pingparam"
 // @Success 200 {object} PingResult
-// @Router api/v1/psping [post]
+// @Router /api/v1/psping [post]
 func (h *Handler) PSPingPeer(node *p2p.Node) echo.HandlerFunc {
 	return func(c echo.Context) (err error) {
 


### PR DESCRIPTION
If you don’t do this, it may cause
```
ParseComment error in file *\quorum\internal\pkg\api\psping.go :can not parse router comment "api/v1/psping [post]"
```