### PR TITLE
feat(ssl): support ip settings when generating ssl certs

### DIFF
--- a/cmd/cli/api/api.go
+++ b/cmd/cli/api/api.go
@@ -339,6 +339,10 @@ func newHTTPClient() (*http.Client, error) {
 		tlsConfig := &tls.Config{
 			RootCAs: caCertPool,
 		}
+		if config.RumConfig.Quorum.ServerSSLInsecure {
+			tlsConfig.InsecureSkipVerify = true
+		}
+
 		tlsConfig.BuildNameToCertificate()
 		transport := &http.Transport{TLSClientConfig: tlsConfig, DisableKeepAlives: true}
 		// 5 seconds timeout, all timeout will be ignored, since we refresh all data every half second

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -16,6 +16,7 @@ var signKeyMap = map[string]string{}
 type QuorumConfig struct {
 	Server               string
 	ServerSSLCertificate string
+	ServerSSLInsecure    bool
 	KeyStoreName         string
 	KeyStoreDir          string
 	KeyStorePass         string

--- a/internal/pkg/cli/flags.go
+++ b/internal/pkg/cli/flags.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"log"
+	"net"
 	"path/filepath"
 	"strings"
 
@@ -10,11 +11,13 @@ import (
 )
 
 type addrList []maddr.Multiaddr
+type ipList []net.IP
 
 type Config struct {
 	RendezvousString   string
 	BootstrapPeers     addrList
 	ListenAddresses    string
+	SSLCertIPAddresses ipList
 	APIListenAddresses string
 	ProtocolID         string
 	IsBootstrap        bool
@@ -49,12 +52,38 @@ func (al *addrList) Set(value string) error {
 	return nil
 }
 
+func (ips *ipList) String() string {
+	strs := make([]string, len(*ips))
+	for i, addr := range *ips {
+		strs[i] = addr.String()
+	}
+	return strings.Join(strs, ",")
+
+}
+
+func (ips *ipList) Set(value string) error {
+	addrlist := strings.Split(value, ",")
+
+	for _, v := range addrlist {
+		addr := net.ParseIP(v)
+		*ips = append(*ips, addr)
+	}
+	return nil
+}
+
+var quorumConfig Config
+
+func GetConfig() Config {
+	return quorumConfig
+}
+
 func ParseFlags() (Config, error) {
 	config := Config{ProtocolID: "/quorum/1.0.0"}
 	flag.StringVar(&config.RendezvousString, "rendezvous", "e6629921-b5cd-4855-9fcd-08bcc39caef7", //e6629921-b5cd-4855-9fcd-08bcc39caef7 default quorum rendezvous
 		"Unique string to identify group of nodes. Share this with your friends to let them connect with you")
 	flag.Var(&config.BootstrapPeers, "peer", "Adds a peer multiaddress to the bootstrap list")
 	flag.StringVar(&config.ListenAddresses, "listen", "/ip4/127.0.0.1/tcp/4215", "Adds a multiaddress to the listen list")
+	flag.Var(&config.SSLCertIPAddresses, "ips", "IPAddresses field of x509 certificate")
 	flag.StringVar(&config.APIListenAddresses, "apilisten", ":5215", "Adds a multiaddress to the listen list")
 	flag.StringVar(&config.PeerName, "peername", "peer", "peername")
 	flag.StringVar(&config.ConfigDir, "configdir", "./config/", "config and keys dir")
@@ -79,5 +108,6 @@ func ParseFlags() (Config, error) {
 	}
 	config.DataDir = dataDir
 
+	quorumConfig = config
 	return config, nil
 }

--- a/internal/pkg/utils/http.go
+++ b/internal/pkg/utils/http.go
@@ -11,11 +11,12 @@ import (
 	"io/ioutil"
 	"log"
 	"math/big"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/rumsystem/quorum/internal/pkg/cli"
 )
 
 // GetTLSCerts get cert file path, return (certPath, keyPath, error)
@@ -64,8 +65,7 @@ func NewTLSCert() (string, string, error) {
 		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-		DNSNames:              []string{"localhost"},
+		IPAddresses:           cli.GetConfig().SSLCertIPAddresses,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 	}

--- a/internal/pkg/utils/http.go
+++ b/internal/pkg/utils/http.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/big"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -55,6 +56,11 @@ func NewTLSCert() (string, string, error) {
 		log.Fatalf("Failed to generate serial number: %v", err)
 	}
 
+	ipAddrs := []net.IP{net.ParseIP("127.0.0.1")}
+	for _, ip := range cli.GetConfig().SSLCertIPAddresses {
+		ipAddrs = append(ipAddrs, ip)
+	}
+
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
@@ -65,7 +71,7 @@ func NewTLSCert() (string, string, error) {
 		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IPAddresses:           cli.GetConfig().SSLCertIPAddresses,
+		IPAddresses:           ipAddrs,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 	}


### PR DESCRIPTION
- add `-ips` flags
- add `ServerSSLInsecure` for cli, to skip verify when cert's IP mismatch