### PR TITLE
debug syncer, record received blockid to prevent ask same block again

### DIFF
--- a/internal/pkg/chain/consensus.go
+++ b/internal/pkg/chain/consensus.go
@@ -4,4 +4,6 @@ type Consensus interface {
 	Name() string
 	Producer() Producer
 	User() User
+	SetProducer(p Producer)
+	SetUser(u User)
 }

--- a/internal/pkg/chain/molasses.go
+++ b/internal/pkg/chain/molasses.go
@@ -23,3 +23,11 @@ func (m *Molasses) Producer() Producer {
 func (m *Molasses) User() User {
 	return m.user
 }
+
+func (m *Molasses) SetProducer(p Producer) {
+	m.producer = p
+}
+
+func (m *Molasses) SetUser(u User) {
+	m.user = u
+}


### PR DESCRIPTION
Debug multi producer
- reuse syncer when load new producer
- when sync, record received block (and provider), prevent call ask_next (ask_previous) for applied block 