### PR TITLE
wasm: bug fixes

### DIFF
--- a/internal/pkg/chain/group.go
+++ b/internal/pkg/chain/group.go
@@ -114,7 +114,7 @@ func (grp *Group) CreateGrp(item *quorumpb.GroupItem) error {
 func (grp *Group) LeaveGrp() error {
 	group_log.Debugf("<%s> LeaveGrp called", grp.Item.GroupId)
 
-	grp.ChainCtx.StopSync()
+	grp.StopSync()
 	//leave pubsub channel
 	grp.ChainCtx.LeaveChannel()
 	group_log.Infof("Group <%s> leaved", grp.Item.GroupId)

--- a/internal/pkg/handlers/cleargroupdata.go
+++ b/internal/pkg/handlers/cleargroupdata.go
@@ -35,6 +35,11 @@ func ClearGroupData(params *ClearGroupDataParam) (*ClearGroupDataResult, error) 
 		return nil, fmt.Errorf("Group %s not exist", params.GroupId)
 	}
 
+	// stop syncing first, to avoid starving in browser (indexeddb)
+	if err := group.StopSync(); err != nil {
+		return nil, err
+	}
+
 	if err := group.ClearGroup(); err != nil {
 		return nil, err
 	}

--- a/internal/pkg/storage/storage.go
+++ b/internal/pkg/storage/storage.go
@@ -7,6 +7,7 @@ type QuorumStorage interface {
 	Delete(key []byte) error
 	Get(key []byte) ([]byte, error)
 	PrefixDelete(prefix []byte) error
+	PrefixCondDelete(prefix []byte, fn func(k []byte, v []byte, err error) (bool, error)) error
 	PrefixForeach(prefix []byte, fn func([]byte, []byte, error) error) error
 	PrefixForeachKey(prefix []byte, valid []byte, reverse bool, fn func([]byte, error) error) error
 	Foreach(fn func([]byte, []byte, error) error) error

--- a/internal/pkg/storage/storage_browser.go
+++ b/internal/pkg/storage/storage_browser.go
@@ -173,6 +173,52 @@ func (s *QSIndexDB) PrefixDelete(prefix []byte) error {
 	return txn.Await(s.ctx)
 }
 
+func (s *QSIndexDB) PrefixCondDelete(prefix []byte, fn func(k []byte, v []byte, err error) (bool, error)) error {
+	txn, _ := s.db.Transaction(idb.TransactionReadWrite, s.name)
+	store, _ := txn.ObjectStore(s.name)
+	kRange, err := idb.NewKeyRangeLowerBound(BytesToArrayBuffer(prefix), false)
+	if err != nil {
+		return err
+	}
+	cursorRequest, err := store.OpenCursorRange(kRange, idb.CursorNext)
+	if err != nil {
+		return err
+	}
+
+	err = cursorRequest.Iter(s.ctx, func(cursor *idb.CursorWithValue) error {
+		key, err := cursor.Key()
+		if err != nil {
+			return err
+		}
+		k := ArrayBufferToBytes(key)
+		if !bytes.HasPrefix(k, prefix) {
+			return nil
+		}
+		value, err := cursor.Value()
+		if err != nil {
+			return err
+		}
+		v := ArrayBufferToBytes(value)
+		del, err := fn(k, v, err)
+		if err != nil {
+			return err
+		}
+		if del {
+			_, err = store.Delete(key)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return txn.Await(s.ctx)
+}
+
 func (s *QSIndexDB) PrefixForeach(prefix []byte, fn func([]byte, []byte, error) error) error {
 	txn, _ := s.db.Transaction(idb.TransactionReadWrite, s.name)
 	store, _ := txn.ObjectStore(s.name)

--- a/internal/pkg/storage/storage_native.go
+++ b/internal/pkg/storage/storage_native.go
@@ -89,11 +89,27 @@ func (s *QSBadger) IsExist(key []byte) (bool, error) {
 }
 
 func (s *QSBadger) PrefixDelete(prefix []byte) error {
-	return s.PrefixForeachKey([]byte(prefix), []byte(prefix), false, func(k []byte, err error) error {
+	return s.PrefixForeachKey(prefix, prefix, false, func(k []byte, err error) error {
 		if err != nil {
 			return err
 		}
 		return s.Delete(k)
+	})
+}
+
+func (s *QSBadger) PrefixCondDelete(prefix []byte, fn func(k []byte, v []byte, err error) (bool, error)) error {
+	return s.PrefixForeach(prefix, func(k []byte, v []byte, err error) error {
+		if err != nil {
+			return err
+		}
+		del, err := fn(k, v, err)
+		if err != nil {
+			return err
+		}
+		if del {
+			return s.Delete(k)
+		}
+		return nil
 	})
 }
 

--- a/pkg/wasm/exception/exception.go
+++ b/pkg/wasm/exception/exception.go
@@ -1,0 +1,42 @@
+// +build js,wasm
+// from https://github.com/hack-pad/go-indexeddb/blob/main/idb/internal/exception/exception.go
+
+package exception
+
+import (
+	"fmt"
+	"syscall/js"
+)
+
+// Catch recovers from panics and attempts to convert the value into an error.
+// Must be used directly in a defer statement, can not be called elsewhere.
+// Set 'err' to the address of the return value, typically with a named return error value.
+// Example: defer exception.Catch(&err)
+func Catch(err *error) {
+	recoverErr := handleRecovery(recover())
+	if recoverErr != nil {
+		*err = recoverErr
+	}
+}
+
+// CatchHandler is the same as Catch, but enables custom error handling after recovering.
+func CatchHandler(fn func(err error)) {
+	err := handleRecovery(recover())
+	if err != nil {
+		fn(err)
+	}
+}
+
+func handleRecovery(r interface{}) error {
+	if r == nil {
+		return nil
+	}
+	switch val := r.(type) {
+	case error:
+		return val
+	case js.Value:
+		return js.Error{Value: val}
+	default:
+		return fmt.Errorf("%+v", val)
+	}
+}

--- a/pkg/wasm/promise.go
+++ b/pkg/wasm/promise.go
@@ -5,6 +5,8 @@ package wasm
 
 import (
 	"syscall/js"
+
+	"github.com/rumsystem/quorum/pkg/wasm/exception"
 )
 
 func Promisefy(fn func() (map[string]interface{}, error)) js.Value {
@@ -12,6 +14,12 @@ func Promisefy(fn func() (map[string]interface{}, error)) js.Value {
 		resolve := args[0]
 		reject := args[1]
 		go func() {
+			panicHandler := func(err error) {
+				if err == nil {
+					reject.Invoke(err.Error())
+				}
+			}
+			defer exception.CatchHandler(panicHandler)
 			ret, err := fn()
 			if err != nil {
 				reject.Invoke(err.Error())

--- a/pkg/wasm/quorum.go
+++ b/pkg/wasm/quorum.go
@@ -183,7 +183,8 @@ func StartDiscoverTask() {
 		logger.Console.Log("Searching for other peers...")
 		peerChan, err := wasmCtx.QNode.RoutingDiscovery.FindPeers(wasmCtx.Ctx, quorumConfig.DefaultRendezvousString)
 		if err != nil {
-			panic(err)
+			logger.Console.Error(err.Error())
+			return
 		}
 
 		var connectCount uint32 = 0
@@ -197,7 +198,6 @@ func StartDiscoverTask() {
 				err := wasmCtx.QNode.Host.Connect(pctx, curPeer)
 				if err != nil {
 					logger.Console.Error("Failed to connect peer: " + curPeer.String())
-					cancel()
 				} else {
 					curConnectedCount := atomic.AddUint32(&connectCount, 1)
 					logger.Console.Log(fmt.Sprintf("Connected to peer(%d): %s", curConnectedCount, curPeer.String()))


### PR DESCRIPTION
- 添加了 panic 恢复的代码（只是 runtime 恢复，还需要方式让前端知道并且重新启动同步服务 TODO）
- 修复了大量数据的情况下，退出群组失败的问题
    - 这里对 RemoveGroupData 进行的小改动，在删数据前调用了一次 group.StopSync
- 新增了一个 storage interface `PrefixCondDelete`，提升删除过程的性能