### PR TITLE
fix: error when building API document

### DIFF
--- a/internal/pkg/api/cleargroupdata.go
+++ b/internal/pkg/api/cleargroupdata.go
@@ -12,7 +12,7 @@ import (
 // @Summary ClearGroupData
 // @Description Clear group data
 // @Produce json
-// @Success 200 {object} ClearGroupDataResult
+// @Success 200 {object} handlers.ClearGroupDataResult
 // @Router /v1/group/clear [post]
 func (h *Handler) ClearGroupData(c echo.Context) (err error) {
 	output := make(map[string]string)

--- a/internal/pkg/api/getgroupproducer.go
+++ b/internal/pkg/api/getgroupproducer.go
@@ -12,7 +12,7 @@ import (
 // @Description Get the list of group producers
 // @Produce json
 // @Param group_id path string  true "Group Id"
-// @Success 200 {array} ProducerListItem
+// @Success 200 {array} handlers.ProducerListItem
 // @Router /api/v1/group/{group_id}/producers [get]
 func (h *Handler) GetGroupProducers(c echo.Context) (err error) {
 	output := make(map[string]string)

--- a/internal/pkg/api/getgroupseed.go
+++ b/internal/pkg/api/getgroupseed.go
@@ -12,7 +12,7 @@ import (
 // @Summary Get group seed
 // @Description get group seed from appdb
 // @Produce json
-// @Success 200 {object} GroupSeed
+// @Success 200 {object} handlers.GroupSeed
 // @Router /api/v1/group/:group_id/seed [get]
 func (h *Handler) GetGroupSeedHandler(c echo.Context) (err error) {
 	groupId := c.Param("group_id")

--- a/internal/pkg/api/getnetwork.go
+++ b/internal/pkg/api/getnetwork.go
@@ -15,7 +15,7 @@ import (
 // @Summary GetNetwork
 // @Description Get node's network information
 // @Produce json
-// @Success 200 {object} NetworkInfo
+// @Success 200 {object} handlers.NetworkInfo
 // @Router /api/v1/network [get]
 func (h *Handler) GetNetwork(nodehost *host.Host, nodeinfo *p2p.NodeInfo, nodeopt *options.NodeOptions, ethaddr string) echo.HandlerFunc {
 	return func(c echo.Context) error {

--- a/internal/pkg/api/getnodeinfo.go
+++ b/internal/pkg/api/getnodeinfo.go
@@ -11,7 +11,7 @@ import (
 // @Summary GetNodeInfo
 // @Description Return the node info
 // @Produce json
-// @Success 200 {object} NodeInfo
+// @Success 200 {object} handlers.NodeInfo
 // @Router /api/v1/node [get]
 func (h *Handler) GetNodeInfo(c echo.Context) (err error) {
 	info, err := handlers.GetNodeInfo(h.Node.NetworkName)

--- a/internal/pkg/api/joingroup.go
+++ b/internal/pkg/api/joingroup.go
@@ -40,7 +40,7 @@ type JoinGroupResult struct {
 // @Description Join a group
 // @Accept json
 // @Produce json
-// @Param data body GroupSeed true "GroupSeed"
+// @Param data body handlers.GroupSeed true "GroupSeed"
 // @Success 200 {object} JoinGroupResult
 // @Router /api/v1/group/join [post]
 func (h *Handler) JoinGroup() echo.HandlerFunc {

--- a/internal/pkg/api/posttogroup.go
+++ b/internal/pkg/api/posttogroup.go
@@ -15,7 +15,7 @@ import (
 // @Accept json
 // @Produce json
 // @Param data body quorumpb.Activity true "Activity object"
-// @Success 200 {object} TrxResult
+// @Success 200 {object} handlers.TrxResult
 // @Router /v1/group/content [post]
 func (h *Handler) PostToGroup(c echo.Context) (err error) {
 


### PR DESCRIPTION
When running `./scripts/swag_init.sh`, I got errors below:

![image](https://user-images.githubusercontent.com/1134765/147944993-d60f0b66-478d-40b4-aec9-b80e97061527.png)

> ParseComment error in file C:\Users\samso\go\src\quorum\internal\pkg\api\cleargroupdata.go :cannot find type definition: ClearGroupDataResult
> ParseComment error in file C:\Users\samso\go\src\quorum\internal\pkg\api\getgroupproducer.go :cannot find type definition: ProducerListItem
> ParseComment error in file C:\Users\samso\go\src\quorum\internal\pkg\api\getgroupseed.go :cannot find type definition: GroupSeed
> ParseComment error in file C:\Users\samso\go\src\quorum\internal\pkg\api\getnetwork.go :cannot find type definition: NetworkInfo
> ParseComment error in file C:\Users\samso\go\src\quorum\internal\pkg\api\joingroup.go :cannot find type definition: GroupSeed
> ParseComment error in file C:\Users\samso\go\src\quorum\internal\pkg\api\posttogroup.go :cannot find type definition: TrxResult

Then I fixed the comments in files. Finally API document was built successfully.