### PR TITLE
update build.sh: OS

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 GIT_COMMIT=$(git rev-list -1 HEAD)
-#darwin windows freebsd
-for GOOS in linux ; do
+#darwin windows freebsd linux
+for GOOS in darwin windows freebsd linux ; do
     for GOARCH in amd64; do
         if [[ "$GOOS" == "windows" ]]; then
             bin="quorum.exe"


### PR DESCRIPTION
让几个 os 都支持编译。
why?  rum app 会编译 quorum 的指定 版本，如果 build.sh 只指定了一个 OS，不方便 rum app 调试用，总是要手动改，有点麻烦。