### PR TITLE
cli: add group config management operations in group admin page

### DIFF
--- a/cmd/cli/api/api.go
+++ b/cmd/cli/api/api.go
@@ -187,6 +187,34 @@ func modifyGroupConfig(action, groupId, key, tp, value, memo string) (*handlers.
 	return &ret, nil
 }
 
+func GetGroupConfigList(groupId string) ([]*handlers.GroupConfigKeyListItem, error) {
+	url := fmt.Sprintf("%s/api/v1/group/%s/config/keylist", ApiServer, groupId)
+	ret := []*handlers.GroupConfigKeyListItem{}
+	body, err := httpGet(url)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(body, &ret)
+	if err != nil {
+		return nil, errors.New(string(body))
+	}
+	return ret, nil
+}
+
+func GetGroupConfig(groupId, key string) (*handlers.GroupConfigKeyItem, error) {
+	url := fmt.Sprintf("%s/api/v1/group/%s/config/%s", ApiServer, groupId, key)
+	ret := handlers.GroupConfigKeyItem{}
+	body, err := httpGet(url)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(body, &ret)
+	if err != nil {
+		return nil, errors.New(string(body))
+	}
+	return &ret, nil
+}
+
 func Nick(groupId string, nick string) (*NickRespStruct, error) {
 	data := NickReqStruct{
 		Person: QuorumPersonStruct{

--- a/cmd/cli/api/api.go
+++ b/cmd/cli/api/api.go
@@ -153,14 +153,14 @@ func IsQuorumContentUserInfo(content ContentStruct) bool {
 }
 
 func AddGroupConfig(groupId, key, tp, value, memo string) (*handlers.GroupConfigResult, error) {
-	return modifyGroupConfig("add", groupId, key, tp, value, memo)
+	return ModifyGroupConfig("add", groupId, key, tp, value, memo)
 }
 
 func DelGroupConfig(groupId, key, tp, value, memo string) (*handlers.GroupConfigResult, error) {
-	return modifyGroupConfig("del", groupId, key, tp, value, memo)
+	return ModifyGroupConfig("del", groupId, key, tp, value, memo)
 }
 
-func modifyGroupConfig(action, groupId, key, tp, value, memo string) (*handlers.GroupConfigResult, error) {
+func ModifyGroupConfig(action, groupId, key, tp, value, memo string) (*handlers.GroupConfigResult, error) {
 	data := handlers.GroupConfigParam{
 		Action:  action,
 		GroupId: groupId,

--- a/cmd/cli/api/api.go
+++ b/cmd/cli/api/api.go
@@ -152,6 +152,41 @@ func IsQuorumContentUserInfo(content ContentStruct) bool {
 	return false
 }
 
+func AddGroupConfig(groupId, key, tp, value, memo string) (*handlers.GroupConfigResult, error) {
+	return modifyGroupConfig("add", groupId, key, tp, value, memo)
+}
+
+func DelGroupConfig(groupId, key, tp, value, memo string) (*handlers.GroupConfigResult, error) {
+	return modifyGroupConfig("del", groupId, key, tp, value, memo)
+}
+
+func modifyGroupConfig(action, groupId, key, tp, value, memo string) (*handlers.GroupConfigResult, error) {
+	data := handlers.GroupConfigParam{
+		Action:  action,
+		GroupId: groupId,
+		Name:    key,
+		Type:    tp,
+		Value:   value,
+		Memo:    memo,
+	}
+	json_data, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	url := ApiServer + "/api/v1/group/config"
+	ret := handlers.GroupConfigResult{}
+	body, err := httpPost(url, json_data)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(body, &ret)
+	if err != nil {
+		return nil, errors.New(string(body))
+	}
+	return &ret, nil
+}
+
 func Nick(groupId string, nick string) (*NickRespStruct, error) {
 	data := NickReqStruct{
 		Person: QuorumPersonStruct{

--- a/cmd/cli/ui/forms.go
+++ b/cmd/cli/ui/forms.go
@@ -8,6 +8,7 @@ import (
 
 	"code.rocketnine.space/tslocum/cview"
 	"github.com/rumsystem/quorum/cmd/cli/api"
+	"github.com/rumsystem/quorum/internal/pkg/handlers"
 )
 
 // global forms
@@ -22,8 +23,93 @@ var groupReqStruct = api.CreateGroupReqStruct{
 	AppKey:         "",
 }
 
+var PANNEL_GROUP_FORM = "form.group"
+var PANNEL_GROUP_CONFIG_FORM = "form.group.config"
+
+var groupConfigForm = cview.NewForm()
+var groupConfigParam = handlers.GroupConfigParam{
+	Action:  "add",
+	GroupId: "",
+	Name:    "",
+	Type:    "",
+	Value:   "",
+	Memo:    "",
+}
+
 func formInit() {
 	createGroupFormInit()
+	groupConfigFormInit()
+}
+
+func groupConfigFormInit() {
+	groupConfigForm.AddDropDownSimple("Action", 0, func(index int, option *cview.DropDownOption) {
+		groupConfigParam.Action = option.GetText()
+	}, "add", "del")
+
+	groupConfigForm.AddInputField("Group Id", "", 40, nil, func(groupId string) {
+		groupConfigParam.GroupId = groupId
+	})
+	groupConfigForm.AddInputField("Name", "", 20, nil, func(name string) {
+		groupConfigParam.Name = name
+	})
+	groupConfigForm.AddDropDownSimple("Type", 0, func(index int, option *cview.DropDownOption) {
+		groupConfigParam.Type = option.GetText()
+	}, "string", "int", "bool")
+	groupConfigForm.AddInputField("Value", "", 20, nil, func(value string) {
+		groupConfigParam.Value = value
+	})
+	groupConfigForm.AddInputField("Memo", "", 20, nil, func(memo string) {
+		groupConfigParam.Memo = memo
+	})
+
+	groupConfigForm.AddButton("OK", func() {
+		if groupConfigParam.GroupId == "" || groupConfigParam.Name == "" {
+			Error("invalid parameter", "GroupId and Name should not be empty")
+			return
+		}
+		go goQuorumUpdateGroupConfig()
+		rootPanels.HidePanel(PANNEL_GROUP_CONFIG_FORM)
+		rootPanels.SendToBack(PANNEL_GROUP_CONFIG_FORM)
+		formMode = false
+	})
+	groupConfigForm.AddButton("Cancel", func() {
+		// backto last
+		rootPanels.HidePanel(PANNEL_GROUP_CONFIG_FORM)
+		rootPanels.SendToBack(PANNEL_GROUP_CONFIG_FORM)
+		formMode = false
+	})
+	groupConfigForm.SetBorder(true)
+	groupConfigForm.SetTitle("Group Config")
+	groupConfigForm.SetTitleAlign(cview.AlignCenter)
+
+	rootPanels.AddPanel(PANNEL_GROUP_CONFIG_FORM, groupConfigForm, true, false)
+}
+
+func GroupConfigFormShow(groupId string, item *handlers.GroupConfigKeyItem) {
+	groupConfigParam.GroupId = groupId
+	groupConfigParam.Name = item.Name
+	groupConfigParam.Type = item.Type
+	groupConfigParam.Value = item.Value
+	groupConfigParam.Memo = item.Memo
+	groupConfigForm.GetFormItemByLabel("Group Id").(*cview.InputField).SetText(groupId)
+	groupConfigForm.GetFormItemByLabel("Name").(*cview.InputField).SetText(item.Name)
+	options := []string{"string", "int", "bool"}
+	var indexOf = func(word string, data []string) int {
+		for k, v := range data {
+			if strings.ToLower(word) == v {
+				return k
+			}
+		}
+		return -1
+	}
+	groupConfigForm.GetFormItemByLabel("Type").(*cview.DropDown).SetCurrentOption(indexOf(item.Type, options))
+	groupConfigForm.GetFormItemByLabel("Value").(*cview.InputField).SetText(item.Value)
+	groupConfigForm.GetFormItemByLabel("Memo").(*cview.InputField).SetText(item.Memo)
+
+	formMode = true
+	rootPanels.ShowPanel(PANNEL_GROUP_CONFIG_FORM)
+	rootPanels.SendToFront(PANNEL_GROUP_CONFIG_FORM)
+	App.SetFocus(groupConfigForm)
 }
 
 func createGroupFormInit() {
@@ -61,27 +147,27 @@ func createGroupFormInit() {
 			return
 		}
 		go goQuorumCreateGroup()
-		rootPanels.HidePanel("form.group")
-		rootPanels.SendToBack("form.group")
+		rootPanels.HidePanel(PANNEL_GROUP_FORM)
+		rootPanels.SendToBack(PANNEL_GROUP_FORM)
 		formMode = false
 	})
 	groupForm.AddButton("Cancel", func() {
 		// backto last
-		rootPanels.HidePanel("form.group")
-		rootPanels.SendToBack("form.group")
+		rootPanels.HidePanel(PANNEL_GROUP_FORM)
+		rootPanels.SendToBack(PANNEL_GROUP_FORM)
 		formMode = false
 	})
 	groupForm.SetBorder(true)
 	groupForm.SetTitle("Create Group")
 	groupForm.SetTitleAlign(cview.AlignCenter)
 
-	rootPanels.AddPanel("form.group", groupForm, true, false)
+	rootPanels.AddPanel(PANNEL_GROUP_FORM, groupForm, true, false)
 }
 
 func CreateGroupForm() {
 	formMode = true
-	rootPanels.ShowPanel("form.group")
-	rootPanels.SendToFront("form.group")
+	rootPanels.ShowPanel(PANNEL_GROUP_CONFIG_FORM)
+	rootPanels.SendToFront(PANNEL_GROUP_CONFIG_FORM)
 	App.SetFocus(groupForm)
 }
 
@@ -117,5 +203,23 @@ func goQuorumCreateGroup() {
 			return
 		}
 		Info(fmt.Sprintf("Group %s created", groupReqStruct.Name), fmt.Sprintf("Seed saved at: %s. Be sure to keep it well.", tmpFile.Name()))
+	}
+}
+
+func goQuorumUpdateGroupConfig() {
+	res, err := api.ModifyGroupConfig(
+		groupConfigParam.Action,
+		groupConfigParam.GroupId,
+		groupConfigParam.Name,
+		groupConfigParam.Type,
+		groupConfigParam.Value,
+		groupConfigParam.Memo,
+	)
+	if err != nil {
+		Error("Failed to update group config", err.Error())
+	} else {
+		cmdInput.SetLabel(fmt.Sprintf("Group %s: ", groupConfigParam.GroupId))
+		cmdInput.SetText("Updated")
+		Info(fmt.Sprintf("Config %s", groupConfigParam.Name), fmt.Sprintf("sign: %s\ntrxid: %s\n", res.Sign, res.TrxId))
 	}
 }

--- a/cmd/cli/ui/page_group_admin.go
+++ b/cmd/cli/ui/page_group_admin.go
@@ -199,17 +199,20 @@ func goGetGroupKeyList(groupId string) {
 	})
 	adminGroupConfigView.SetSelectedFunc(func(row int, column int) {
 		if row == 0 {
-			// ignore header
-			return
-		}
-		for i := 0; i < adminGroupConfigView.GetColumnCount(); i++ {
-			adminGroupConfigView.GetCell(row, i).SetTextColor(tcell.ColorRed.TrueColor())
-		}
-		idx := row - 1
-		if idx >= 0 && idx < len(keys) {
-			key := keys[idx].Name
-			item, _ := api.GetGroupConfig(groupId, key)
+			// create new config
+			item := &handlers.GroupConfigKeyItem{}
+			item.Type = "string"
 			GroupConfigFormShow(groupId, item)
+		} else {
+			for i := 0; i < adminGroupConfigView.GetColumnCount(); i++ {
+				adminGroupConfigView.GetCell(row, i).SetTextColor(tcell.ColorRed.TrueColor())
+			}
+			idx := row - 1
+			if idx >= 0 && idx < len(keys) {
+				key := keys[idx].Name
+				item, _ := api.GetGroupConfig(groupId, key)
+				GroupConfigFormShow(groupId, item)
+			}
 		}
 		adminGroupConfigView.SetSelectable(false, false)
 	})

--- a/cmd/cli/ui/page_group_admin.go
+++ b/cmd/cli/ui/page_group_admin.go
@@ -25,62 +25,95 @@ var adminPageHelpText = strings.TrimSpace(
 )
 
 var adminPage = cview.NewFlex()
-var adminPageLeft = cview.NewTextView()  // users
-var adminPageRight = cview.NewTextView() // producers
-
-var adminApproveModal = cview.NewModal()
+var adminPageAnnouncedUsersView = cview.NewTextView()     // announced users
+var adminPageAnnouncedProducersView = cview.NewTextView() // announced producers
+var adminAnnouncedApproveModal = cview.NewModal()         // announced users/producers approval modal
+var adminGroupConfigView = cview.NewTable()               // Config List
 
 func adminPageInit() {
-	adminPageLeft.SetTitle("Announced Users")
-	adminPageLeft.SetBorder(true)
-	adminPageLeft.SetRegions(true)
-	adminPageLeft.SetDynamicColors(true)
+	adminPageAnnouncedUsersView.SetTitle("Announced Users")
+	adminPageAnnouncedUsersView.SetBorder(true)
+	adminPageAnnouncedUsersView.SetRegions(true)
+	adminPageAnnouncedUsersView.SetDynamicColors(true)
 
-	adminPageRight.SetTitle("Announced Producers")
-	adminPageRight.SetBorder(true)
-	adminPageRight.SetRegions(true)
-	adminPageRight.SetDynamicColors(true)
+	adminPageAnnouncedProducersView.SetTitle("Announced Producers")
+	adminPageAnnouncedProducersView.SetBorder(true)
+	adminPageAnnouncedProducersView.SetRegions(true)
+	adminPageAnnouncedProducersView.SetDynamicColors(true)
 
-	adminApproveModal.SetBackgroundColor(tcell.ColorBlack)
-	adminApproveModal.SetButtonBackgroundColor(tcell.ColorWhite)
-	adminApproveModal.SetButtonTextColor(tcell.ColorBlack)
-	adminApproveModal.SetTextColor(tcell.ColorWhite)
-	adminApproveModal.SetTitle("Operation")
-	adminApproveModal.SetText("Approve selected user?")
-	adminApproveModal.AddButtons([]string{"Approve", "Deny", "Close"})
-	rootPanels.AddPanel("adminApproveModal", adminApproveModal, false, false)
-	rootPanels.HidePanel("adminApproveModal")
+	adminGroupConfigView.SetBorders(true)
+
+	cols, rows := 10, 40
+	for r := 0; r < rows; r++ {
+		for c := 0; c < cols; c++ {
+			color := tcell.ColorWhite.TrueColor()
+			if c < 1 || r < 1 {
+				color = tcell.ColorYellow.TrueColor()
+			}
+			cell := cview.NewTableCell("hello")
+			cell.SetTextColor(color)
+			cell.SetAlign(cview.AlignCenter)
+			adminGroupConfigView.SetCell(r, c, cell)
+		}
+	}
+
+	adminAnnouncedApproveModal.SetBackgroundColor(tcell.ColorBlack)
+	adminAnnouncedApproveModal.SetButtonBackgroundColor(tcell.ColorWhite)
+	adminAnnouncedApproveModal.SetButtonTextColor(tcell.ColorBlack)
+	adminAnnouncedApproveModal.SetTextColor(tcell.ColorWhite)
+	adminAnnouncedApproveModal.SetTitle("Operation")
+	adminAnnouncedApproveModal.SetText("Approve selected user?")
+	adminAnnouncedApproveModal.AddButtons([]string{"Approve", "Deny", "Close"})
+
+	rootPanels.AddPanel("adminAnnouncedApproveModal", adminAnnouncedApproveModal, false, false)
+	rootPanels.HidePanel("adminAnnouncedApproveModal")
 
 	initAdminPageInputHandler()
 
-	// short cut
-	adminPage.AddItem(adminPageLeft, 0, 1, false)
-	adminPage.AddItem(adminPageRight, 0, 1, false)
+	leftFlex := cview.NewFlex()
+	leftFlex.SetDirection(cview.FlexRow)
+	leftFlex.AddItem(adminPageAnnouncedUsersView, 0, 1, false)
+	leftFlex.AddItem(adminPageAnnouncedProducersView, 0, 1, false)
+
+	adminPage.AddItem(leftFlex, 0, 1, false)
+	adminPage.AddItem(adminGroupConfigView, 0, 1, false)
 
 	rootPanels.AddPanel("admin", adminPage, true, false)
 }
 
-var focusLeftView = func() { App.SetFocus(adminPageLeft) }
-var focusRightView = func() { App.SetFocus(adminPageRight) }
+var focusAnnouncedUsersViewView = func() { App.SetFocus(adminPageAnnouncedUsersView) }
+var focusAnnouncedProducersView = func() { App.SetFocus(adminPageAnnouncedProducersView) }
+var focusGroupConfigView = func() { App.SetFocus(adminGroupConfigView) }
 
 func initAdminPageInputHandler() {
-	leftViewHandler := cbind.NewConfiguration()
+	announcedUsersHandler := cbind.NewConfiguration()
 	if runtime.GOOS == "windows" {
 		// windows will set extra shift mod somehow
-		leftViewHandler.Set("Shift+L", wrapQuorumKeyFn(focusRightView))
+		announcedUsersHandler.Set("Shift+J", wrapQuorumKeyFn(focusAnnouncedProducersView))
+		announcedUsersHandler.Set("Shift+L", wrapQuorumKeyFn(focusGroupConfigView))
 	} else {
-		leftViewHandler.Set("L", wrapQuorumKeyFn(focusRightView))
+		announcedUsersHandler.Set("J", wrapQuorumKeyFn(focusAnnouncedProducersView))
+		announcedUsersHandler.Set("L", wrapQuorumKeyFn(focusGroupConfigView))
 	}
-	adminPageLeft.SetInputCapture(leftViewHandler.Capture)
+	adminPageAnnouncedUsersView.SetInputCapture(announcedUsersHandler.Capture)
 
-	rightViewHandler := cbind.NewConfiguration()
+	announcedProducersHandler := cbind.NewConfiguration()
 	if runtime.GOOS == "windows" {
-		rightViewHandler.Set("Shift+H", wrapQuorumKeyFn(focusLeftView))
+		announcedProducersHandler.Set("Shift+K", wrapQuorumKeyFn(focusAnnouncedUsersViewView))
+		announcedProducersHandler.Set("Shift+L", wrapQuorumKeyFn(focusGroupConfigView))
 	} else {
-		rightViewHandler.Set("H", wrapQuorumKeyFn(focusLeftView))
+		announcedProducersHandler.Set("K", wrapQuorumKeyFn(focusAnnouncedUsersViewView))
+		announcedProducersHandler.Set("L", wrapQuorumKeyFn(focusGroupConfigView))
 	}
-	adminPageRight.SetInputCapture(rightViewHandler.Capture)
+	adminPageAnnouncedProducersView.SetInputCapture(announcedProducersHandler.Capture)
 
+	groupConfigHandler := cbind.NewConfiguration()
+	if runtime.GOOS == "windows" {
+		groupConfigHandler.Set("Shift+H", wrapQuorumKeyFn(focusAnnouncedUsersViewView))
+	} else {
+		groupConfigHandler.Set("H", wrapQuorumKeyFn(focusAnnouncedUsersViewView))
+	}
+	adminGroupConfigView.SetInputCapture(groupConfigHandler.Capture)
 }
 
 func GroupAdminPage(groupId string) {
@@ -93,7 +126,7 @@ func GroupAdminPage(groupId string) {
 	}
 
 	pageInputHandler := cbind.NewConfiguration()
-	pageInputHandler.Set("Enter", wrapQuorumKeyFn(focusLeftView))
+	pageInputHandler.Set("Enter", wrapQuorumKeyFn(focusAnnouncedUsersViewView))
 	pageInputHandler.Set("Esc", wrapQuorumKeyFn(focusLastView))
 	pageInputHandler.Set("r", wrapQuorumKeyFn(func() {
 		AdminRefreshAll(groupId)
@@ -119,79 +152,79 @@ func goGetAnnouncedUsers(groupId string) {
 	aUsers, err := api.AnnouncedUsers(groupId)
 	checkFatalError(err)
 
-	adminPageLeft.Clear()
+	adminPageAnnouncedUsersView.Clear()
 
 	for i, each := range aUsers {
-		fmt.Fprintf(adminPageLeft, "[\"%d\"]%s %s\n", i, each.Result, time.Unix(0, each.TimeStamp))
-		fmt.Fprintf(adminPageLeft, "AnnouncedSignPubkey: %s\n", each.AnnouncedSignPubkey)
-		fmt.Fprintf(adminPageLeft, "AnnouncedEncryptPubkey: %s\n", each.AnnouncedEncryptPubkey)
-		fmt.Fprintf(adminPageLeft, "AnnouncerSign: %s\n", each.AnnouncerSign)
-		fmt.Fprintf(adminPageLeft, "Memo: %s\n", each.Memo)
-		fmt.Fprintf(adminPageLeft, "\n\n")
+		fmt.Fprintf(adminPageAnnouncedUsersView, "[\"%d\"]%s %s\n", i, each.Result, time.Unix(0, each.TimeStamp))
+		fmt.Fprintf(adminPageAnnouncedUsersView, "AnnouncedSignPubkey: %s\n", each.AnnouncedSignPubkey)
+		fmt.Fprintf(adminPageAnnouncedUsersView, "AnnouncedEncryptPubkey: %s\n", each.AnnouncedEncryptPubkey)
+		fmt.Fprintf(adminPageAnnouncedUsersView, "AnnouncerSign: %s\n", each.AnnouncerSign)
+		fmt.Fprintf(adminPageAnnouncedUsersView, "Memo: %s\n", each.Memo)
+		fmt.Fprintf(adminPageAnnouncedUsersView, "\n\n")
 	}
 
 	selectNextUser := func() {
 		minNum := 0
 		maxNum := len(aUsers) - 1
 
-		curSelection := adminPageLeft.GetHighlights()
+		curSelection := adminPageAnnouncedUsersView.GetHighlights()
 		tag := minNum
 		if len(curSelection) > 0 {
 			tag, _ = strconv.Atoi(curSelection[0])
 			tag += 1
 		}
 		if tag >= minNum && tag <= maxNum {
-			adminPageLeft.Highlight(strconv.Itoa(tag))
-			adminPageLeft.ScrollToHighlight()
+			adminPageAnnouncedUsersView.Highlight(strconv.Itoa(tag))
+			adminPageAnnouncedUsersView.ScrollToHighlight()
 		}
 	}
 	selectLastUser := func() {
 		minNum := 0
 		maxNum := len(aUsers) - 1
 
-		curSelection := adminPageLeft.GetHighlights()
+		curSelection := adminPageAnnouncedUsersView.GetHighlights()
 		tag := minNum
 		if len(curSelection) > 0 {
 			tag, _ = strconv.Atoi(curSelection[0])
 			tag -= 1
 		}
 		if tag >= minNum && tag <= maxNum {
-			adminPageLeft.Highlight(strconv.Itoa(tag))
-			adminPageLeft.ScrollToHighlight()
+			adminPageAnnouncedUsersView.Highlight(strconv.Itoa(tag))
+			adminPageAnnouncedUsersView.ScrollToHighlight()
 		}
 	}
-	adminPageLeft.SetDoneFunc(func(key tcell.Key) {
+	adminPageAnnouncedUsersView.SetDoneFunc(func(key tcell.Key) {
 		switch key {
 		case tcell.KeyEsc:
-			adminPageLeft.Highlight("")
+			adminPageAnnouncedUsersView.Highlight("")
 			cmdInput.SetLabel("")
 			cmdInput.SetText("")
 		case tcell.KeyEnter:
-			curSelection := adminPageLeft.GetHighlights()
+			curSelection := adminPageAnnouncedUsersView.GetHighlights()
 			if len(curSelection) > 0 {
 				idx, _ := strconv.Atoi(curSelection[0])
 				user := aUsers[idx]
-				adminApproveModal.SetText("Approve user with memo: " + user.Memo + "?")
-				adminApproveModal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+				adminAnnouncedApproveModal.SetText("Approve user with memo: " + user.Memo + "?")
+				adminAnnouncedApproveModal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 					switch buttonIndex {
 					case 0:
 						// approve
 						go goApprove(groupId, user, false)
-						rootPanels.HidePanel("adminApproveModal")
+						rootPanels.HidePanel("adminAnnouncedApproveModal")
 						Info("Syncing...", "Keep waiting and press `r` to refresh")
 					case 1:
 						// delete
 						go goApprove(groupId, user, true)
-						rootPanels.HidePanel("adminApproveModal")
+						rootPanels.HidePanel("adminAnnouncedApproveModal")
 						Info("Syncing...", "Keep waiting and press `r` to refresh")
 					case 2:
 						// abort operation
-						rootPanels.HidePanel("adminApproveModal")
+						rootPanels.HidePanel("adminAnnouncedApproveModal")
 					}
 				})
-				rootPanels.ShowPanel("adminApproveModal")
-				rootPanels.SendToFront("adminApproveModal")
-				App.SetFocus(adminApproveModal)
+				rootPanels.ShowPanel("adminAnnouncedApproveModal")
+				rootPanels.SendToFront("adminAnnouncedApproveModal")
+				App.SetFocus(adminAnnouncedApproveModal)
 				App.Draw()
 			}
 
@@ -208,78 +241,78 @@ func goGetAnnouncedProducers(groupId string) {
 	aProducers, err := api.AnnouncedProducers(groupId)
 	checkFatalError(err)
 
-	adminPageRight.Clear()
+	adminPageAnnouncedProducersView.Clear()
 
 	for i, each := range aProducers {
-		fmt.Fprintf(adminPageRight, "[\"%d\"]%s %s\n", i, each.Result, time.Unix(0, each.TimeStamp))
-		fmt.Fprintf(adminPageRight, "AnnouncedPubkey: %s\n", each.AnnouncedPubkey)
-		fmt.Fprintf(adminPageRight, "AnnouncerSign: %s\n", each.AnnouncerSign)
-		fmt.Fprintf(adminPageRight, "Memo: %s\n", each.Memo)
-		fmt.Fprintf(adminPageRight, "\n\n")
+		fmt.Fprintf(adminPageAnnouncedProducersView, "[\"%d\"]%s %s\n", i, each.Result, time.Unix(0, each.TimeStamp))
+		fmt.Fprintf(adminPageAnnouncedProducersView, "AnnouncedPubkey: %s\n", each.AnnouncedPubkey)
+		fmt.Fprintf(adminPageAnnouncedProducersView, "AnnouncerSign: %s\n", each.AnnouncerSign)
+		fmt.Fprintf(adminPageAnnouncedProducersView, "Memo: %s\n", each.Memo)
+		fmt.Fprintf(adminPageAnnouncedProducersView, "\n\n")
 	}
 
 	selectNextUser := func() {
 		minNum := 0
 		maxNum := len(aProducers) - 1
 
-		curSelection := adminPageRight.GetHighlights()
+		curSelection := adminPageAnnouncedProducersView.GetHighlights()
 		tag := minNum
 		if len(curSelection) > 0 {
 			tag, _ = strconv.Atoi(curSelection[0])
 			tag += 1
 		}
 		if tag >= minNum && tag <= maxNum {
-			adminPageRight.Highlight(strconv.Itoa(tag))
-			adminPageRight.ScrollToHighlight()
+			adminPageAnnouncedProducersView.Highlight(strconv.Itoa(tag))
+			adminPageAnnouncedProducersView.ScrollToHighlight()
 		}
 	}
 	selectLastUser := func() {
 		minNum := 0
 		maxNum := len(aProducers) - 1
 
-		curSelection := adminPageRight.GetHighlights()
+		curSelection := adminPageAnnouncedProducersView.GetHighlights()
 		tag := minNum
 		if len(curSelection) > 0 {
 			tag, _ = strconv.Atoi(curSelection[0])
 			tag -= 1
 		}
 		if tag >= minNum && tag <= maxNum {
-			adminPageRight.Highlight(strconv.Itoa(tag))
-			adminPageRight.ScrollToHighlight()
+			adminPageAnnouncedProducersView.Highlight(strconv.Itoa(tag))
+			adminPageAnnouncedProducersView.ScrollToHighlight()
 		}
 	}
-	adminPageRight.SetDoneFunc(func(key tcell.Key) {
+	adminPageAnnouncedProducersView.SetDoneFunc(func(key tcell.Key) {
 		switch key {
 		case tcell.KeyEsc:
-			adminPageRight.Highlight("")
+			adminPageAnnouncedProducersView.Highlight("")
 			cmdInput.SetLabel("")
 			cmdInput.SetText("")
 		case tcell.KeyEnter:
-			curSelection := adminPageRight.GetHighlights()
+			curSelection := adminPageAnnouncedProducersView.GetHighlights()
 			if len(curSelection) > 0 {
 				idx, _ := strconv.Atoi(curSelection[0])
 				user := aProducers[idx]
-				adminApproveModal.SetText("Approve producer with memo: " + user.Memo + "?")
-				adminApproveModal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+				adminAnnouncedApproveModal.SetText("Approve producer with memo: " + user.Memo + "?")
+				adminAnnouncedApproveModal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 					switch buttonIndex {
 					case 0:
 						// approve
 						go goApproveProducer(groupId, user, false)
-						rootPanels.HidePanel("adminApproveModal")
+						rootPanels.HidePanel("adminAnnouncedApproveModal")
 						Info("Syncing...", "Keep waiting and press `r` to refresh")
 					case 1:
 						// delete
 						go goApproveProducer(groupId, user, true)
-						rootPanels.HidePanel("adminApproveModal")
+						rootPanels.HidePanel("adminAnnouncedApproveModal")
 						Info("Syncing...", "Keep waiting and press `r` to refresh")
 					case 2:
 						// abort operation
-						rootPanels.HidePanel("adminApproveModal")
+						rootPanels.HidePanel("adminAnnouncedApproveModal")
 					}
 				})
-				rootPanels.ShowPanel("adminApproveModal")
-				rootPanels.SendToFront("adminApproveModal")
-				App.SetFocus(adminApproveModal)
+				rootPanels.ShowPanel("adminAnnouncedApproveModal")
+				rootPanels.SendToFront("adminAnnouncedApproveModal")
+				App.SetFocus(adminAnnouncedApproveModal)
 				App.Draw()
 			}
 

--- a/cmd/cli/ui/page_group_admin.go
+++ b/cmd/cli/ui/page_group_admin.go
@@ -43,20 +43,6 @@ func adminPageInit() {
 
 	adminGroupConfigView.SetBorders(true)
 
-	cols, rows := 10, 40
-	for r := 0; r < rows; r++ {
-		for c := 0; c < cols; c++ {
-			color := tcell.ColorWhite.TrueColor()
-			if c < 1 || r < 1 {
-				color = tcell.ColorYellow.TrueColor()
-			}
-			cell := cview.NewTableCell("hello")
-			cell.SetTextColor(color)
-			cell.SetAlign(cview.AlignCenter)
-			adminGroupConfigView.SetCell(r, c, cell)
-		}
-	}
-
 	adminAnnouncedApproveModal.SetBackgroundColor(tcell.ColorBlack)
 	adminAnnouncedApproveModal.SetButtonBackgroundColor(tcell.ColorWhite)
 	adminAnnouncedApproveModal.SetButtonTextColor(tcell.ColorBlack)
@@ -150,6 +136,67 @@ func GroupAdminPage(groupId string) {
 func AdminRefreshAll(groupId string) {
 	go goGetAnnouncedUsers(groupId)
 	go goGetAnnouncedProducers(groupId)
+	go goGetGroupKeyList(groupId)
+}
+
+func goGetGroupKeyList(groupId string) {
+	keys, err := api.GetGroupConfigList(groupId)
+	checkFatalError(err)
+
+	adminGroupConfigView.Clear()
+
+	// init table header
+	color := tcell.ColorYellow.TrueColor()
+	cell := cview.NewTableCell("key")
+	cell.SetTextColor(color)
+	cell.SetAlign(cview.AlignCenter)
+	adminGroupConfigView.SetCell(0, 0, cell)
+	cell = cview.NewTableCell("type")
+	cell.SetTextColor(color)
+	cell.SetAlign(cview.AlignCenter)
+	adminGroupConfigView.SetCell(0, 1, cell)
+	cell = cview.NewTableCell("value")
+	cell.SetTextColor(color)
+	cell.SetAlign(cview.AlignCenter)
+	adminGroupConfigView.SetCell(0, 2, cell)
+	cell = cview.NewTableCell("memo")
+	cell.SetTextColor(color)
+	cell.SetAlign(cview.AlignCenter)
+	adminGroupConfigView.SetCell(0, 3, cell)
+
+	adminGroupConfigView.SetFixed(0, 0)
+	adminGroupConfigView.SetFixed(0, 1)
+	adminGroupConfigView.SetFixed(0, 2)
+	adminGroupConfigView.SetFixed(0, 3)
+
+	for i, each := range keys {
+		row := i + 1
+		k := each.Name
+		color := tcell.ColorWhite.TrueColor()
+		cell := cview.NewTableCell(k)
+		cell.SetTextColor(color)
+		cell.SetAlign(cview.AlignCenter)
+		adminGroupConfigView.SetCell(row, 0, cell)
+		cell = cview.NewTableCell(each.Type)
+		cell.SetTextColor(color)
+		cell.SetAlign(cview.AlignCenter)
+		adminGroupConfigView.SetCell(row, 1, cell)
+		go func() {
+			detail, err := api.GetGroupConfig(groupId, k)
+			if err != nil {
+				return
+			}
+			cell := cview.NewTableCell(detail.Value)
+			cell.SetTextColor(color)
+			cell.SetAlign(cview.AlignCenter)
+			adminGroupConfigView.SetCell(row, 2, cell)
+			cell = cview.NewTableCell(detail.Memo)
+			cell.SetTextColor(color)
+			cell.SetAlign(cview.AlignCenter)
+			adminGroupConfigView.SetCell(row, 3, cell)
+		}()
+	}
+
 }
 
 func goGetAnnouncedUsers(groupId string) {

--- a/cmd/cli/ui/page_group_admin.go
+++ b/cmd/cli/ui/page_group_admin.go
@@ -84,6 +84,7 @@ func adminPageInit() {
 var focusAnnouncedUsersViewView = func() { App.SetFocus(adminPageAnnouncedUsersView) }
 var focusAnnouncedProducersView = func() { App.SetFocus(adminPageAnnouncedProducersView) }
 var focusGroupConfigView = func() { App.SetFocus(adminGroupConfigView) }
+var focusAdminRootView = func() { App.SetFocus(rootPanels) }
 
 func initAdminPageInputHandler() {
 	announcedUsersHandler := cbind.NewConfiguration()
@@ -95,6 +96,7 @@ func initAdminPageInputHandler() {
 		announcedUsersHandler.Set("J", wrapQuorumKeyFn(focusAnnouncedProducersView))
 		announcedUsersHandler.Set("L", wrapQuorumKeyFn(focusGroupConfigView))
 	}
+	announcedUsersHandler.Set("Esc", wrapQuorumKeyFn(focusAdminRootView))
 	adminPageAnnouncedUsersView.SetInputCapture(announcedUsersHandler.Capture)
 
 	announcedProducersHandler := cbind.NewConfiguration()
@@ -105,6 +107,7 @@ func initAdminPageInputHandler() {
 		announcedProducersHandler.Set("K", wrapQuorumKeyFn(focusAnnouncedUsersViewView))
 		announcedProducersHandler.Set("L", wrapQuorumKeyFn(focusGroupConfigView))
 	}
+	announcedProducersHandler.Set("Esc", wrapQuorumKeyFn(focusAdminRootView))
 	adminPageAnnouncedProducersView.SetInputCapture(announcedProducersHandler.Capture)
 
 	groupConfigHandler := cbind.NewConfiguration()
@@ -113,6 +116,7 @@ func initAdminPageInputHandler() {
 	} else {
 		groupConfigHandler.Set("H", wrapQuorumKeyFn(focusAnnouncedUsersViewView))
 	}
+	groupConfigHandler.Set("Esc", wrapQuorumKeyFn(focusAdminRootView))
 	adminGroupConfigView.SetInputCapture(groupConfigHandler.Capture)
 }
 


### PR DESCRIPTION
use `/group.admin` to enter the management UI. Following things are done in this PR.

- refactored UI layout to add space for group config management
- added a global form for updating group configs.

related API

- POST  `/api/v1/group/config`
- GET `/api/v1/group/:group_id/config/keylist`
- GET `/api//v1/group/:group_id/config/:key`