### PR TITLE
refactor: `Storage` interface

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -477,7 +477,7 @@ func main() {
 		logging.SetLogLevel("network", "debug")
 		logging.SetLogLevel("autonat", "debug")
 		logging.SetLogLevel("chain", "debug")
-		//logging.SetLogLevel("dbmgr", "debug")
+		logging.SetLogLevel("dbmgr", "debug")
 		logging.SetLogLevel("chainctx", "debug")
 		logging.SetLogLevel("syncer", "debug")
 		logging.SetLogLevel("producer", "debug")
@@ -489,9 +489,9 @@ func main() {
 		//logging.SetLogLevel("group", "debug")
 		//logging.SetLogLevel("user", "debug")
 		//logging.SetLogLevel("groupmgr", "debug")
-		//logging.SetLogLevel("ping", "debug")
+		logging.SetLogLevel("ping", "debug")
 		logging.SetLogLevel("chan", "debug")
-		//logging.SetLogLevel("pubsub", "debug")
+		logging.SetLogLevel("pubsub", "debug")
 	}
 
 	if *help {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -491,7 +491,7 @@ func main() {
 		//logging.SetLogLevel("groupmgr", "debug")
 		logging.SetLogLevel("ping", "debug")
 		logging.SetLogLevel("chan", "debug")
-		logging.SetLogLevel("pubsub", "debug")
+		//logging.SetLogLevel("pubsub", "debug")
 	}
 
 	if *help {

--- a/internal/pkg/appdata/db.go
+++ b/internal/pkg/appdata/db.go
@@ -90,7 +90,7 @@ func (appdb *AppDb) GetGroupContentBySenders(groupid string, senders []string, s
 		runcollector = true //no trxid, start collecting from the first item
 	}
 
-	err := appdb.Db.PrefixForeachKey(p, []byte(prefix), reverse, func(k []byte, err error) error {
+	_, err := appdb.Db.PrefixForeachKey(p, []byte(prefix), reverse, func(k []byte, err error) error {
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/chainsdk/core/group.go
+++ b/internal/pkg/chainsdk/core/group.go
@@ -140,7 +140,7 @@ func (grp *Group) LeaveGrp() error {
 }
 
 func (grp *Group) ClearGroup() error {
-	return nodectx.GetDbMgr().RemoveGroupData(grp.Item, grp.ChainCtx.nodename)
+	return nodectx.GetDbMgr().RemoveGroupData(grp.Item.GroupId, grp.ChainCtx.nodename)
 }
 
 func (grp *Group) StartSync() error {

--- a/internal/pkg/storage/dbmgr.go
+++ b/internal/pkg/storage/dbmgr.go
@@ -603,44 +603,44 @@ func (dbMgr *DbMgr) ApproveRelayReq(reqid string) (bool, *quorumpb.GroupRelayIte
 	return succ, &relayreq, err
 }
 
-func (dbMgr *DbMgr) RemoveGroupData(item *quorumpb.GroupItem, prefix ...string) error {
+func (dbMgr *DbMgr) RemoveGroupData(groupId string, prefix ...string) error {
 	nodeprefix := utils.GetPrefix(prefix...)
 	var keys []string
 
 	//remove all group POST
-	key := nodeprefix + GRP_PREFIX + "_" + CNT_PREFIX + "_" + item.GroupId
+	key := nodeprefix + GRP_PREFIX + "_" + CNT_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//all group producer
-	key = nodeprefix + PRD_PREFIX + "_" + item.GroupId
+	key = nodeprefix + PRD_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//all group users
-	key = nodeprefix + USR_PREFIX + "_" + item.GroupId
+	key = nodeprefix + USR_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//all group announced item
-	key = nodeprefix + ANN_PREFIX + "_" + item.GroupId
+	key = nodeprefix + ANN_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//all group schema item
-	key = nodeprefix + SMA_PREFIX + "_" + item.GroupId
+	key = nodeprefix + SMA_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//all group chain_config item
-	key = nodeprefix + CHAIN_CONFIG_PREFIX + "_" + item.GroupId
+	key = nodeprefix + CHAIN_CONFIG_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//all group app_config item
-	key = nodeprefix + APP_CONFIG_PREFIX + "_" + item.GroupId
+	key = nodeprefix + APP_CONFIG_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//nonce prefix
-	key = nodeprefix + NONCE_PREFIX + "_" + item.GroupId
+	key = nodeprefix + NONCE_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//snapshot
-	key = nodeprefix + SNAPSHOT_PREFIX + "_" + item.GroupId
+	key = nodeprefix + SNAPSHOT_PREFIX + "_" + groupId
 	keys = append(keys, key)
 
 	//remove all
@@ -671,7 +671,7 @@ func (dbMgr *DbMgr) RemoveGroupData(item *quorumpb.GroupItem, prefix ...string) 
 				return false, perr
 			}
 
-			if blockChunk.BlockItem.GroupId == item.GroupId {
+			if blockChunk.BlockItem.GroupId == groupId {
 				return true, nil
 			}
 			return false, nil
@@ -697,7 +697,7 @@ func (dbMgr *DbMgr) RemoveGroupData(item *quorumpb.GroupItem, prefix ...string) 
 			return false, perr
 		}
 
-		if trx.GroupId == item.GroupId {
+		if trx.GroupId == groupId {
 			return true, nil
 		}
 

--- a/internal/pkg/storage/dbmgr.go
+++ b/internal/pkg/storage/dbmgr.go
@@ -645,10 +645,11 @@ func (dbMgr *DbMgr) RemoveGroupData(item *quorumpb.GroupItem, prefix ...string) 
 
 	//remove all
 	for _, key_prefix := range keys {
-		err := dbMgr.Db.PrefixDelete([]byte(key_prefix))
+		n, err := dbMgr.Db.PrefixDelete([]byte(key_prefix))
 		if err != nil {
 			return err
 		}
+		dbmgr_log.Debugf("removed key with prefix %s: %d", key_prefix, n)
 	}
 
 	keys = nil
@@ -659,7 +660,7 @@ func (dbMgr *DbMgr) RemoveGroupData(item *quorumpb.GroupItem, prefix ...string) 
 	keys = append(keys, key)
 
 	for _, key_prefix := range keys {
-		err := dbMgr.Db.PrefixCondDelete([]byte(key_prefix), func(k []byte, v []byte, err error) (bool, error) {
+		n, err := dbMgr.Db.PrefixCondDelete([]byte(key_prefix), func(k []byte, v []byte, err error) (bool, error) {
 			if err != nil {
 				return false, err
 			}
@@ -679,11 +680,12 @@ func (dbMgr *DbMgr) RemoveGroupData(item *quorumpb.GroupItem, prefix ...string) 
 		if err != nil {
 			return err
 		}
+		dbmgr_log.Debugf("removed key with prefix %s: %d", key_prefix, n)
 	}
 
-	//remove all trx
+	// remove all trx
 	key = nodeprefix + TRX_PREFIX + "_"
-	err := dbMgr.Db.PrefixCondDelete([]byte(key), func(k []byte, v []byte, err error) (bool, error) {
+	n, err := dbMgr.Db.PrefixCondDelete([]byte(key), func(k []byte, v []byte, err error) (bool, error) {
 		if err != nil {
 			return false, err
 		}
@@ -701,6 +703,7 @@ func (dbMgr *DbMgr) RemoveGroupData(item *quorumpb.GroupItem, prefix ...string) 
 
 		return false, nil
 	})
+	dbmgr_log.Debugf("PrefixCondDelete key with prefix %s: %d", key, n)
 
 	if err != nil {
 		return err

--- a/internal/pkg/storage/storage.go
+++ b/internal/pkg/storage/storage.go
@@ -6,10 +6,10 @@ type QuorumStorage interface {
 	Set(key []byte, val []byte) error
 	Delete(key []byte) error
 	Get(key []byte) ([]byte, error)
-	PrefixDelete(prefix []byte) error
-	PrefixCondDelete(prefix []byte, fn func(k []byte, v []byte, err error) (bool, error)) error
+	PrefixDelete(prefix []byte) (int, error)
+	PrefixCondDelete(prefix []byte, fn func(k []byte, v []byte, err error) (bool, error)) (int, error)
 	PrefixForeach(prefix []byte, fn func([]byte, []byte, error) error) error
-	PrefixForeachKey(prefix []byte, valid []byte, reverse bool, fn func([]byte, error) error) error
+	PrefixForeachKey(prefix []byte, valid []byte, reverse bool, fn func([]byte, error) error) (int, error)
 	Foreach(fn func([]byte, []byte, error) error) error
 	IsExist([]byte) (bool, error)
 

--- a/internal/pkg/storage/storage.go
+++ b/internal/pkg/storage/storage.go
@@ -8,8 +8,8 @@ type QuorumStorage interface {
 	Get(key []byte) ([]byte, error)
 	PrefixDelete(prefix []byte) (int, error)
 	PrefixCondDelete(prefix []byte, fn func(k []byte, v []byte, err error) (bool, error)) (int, error)
-	PrefixForeach(prefix []byte, fn func([]byte, []byte, error) error) error
 	PrefixForeachKey(prefix []byte, valid []byte, reverse bool, fn func([]byte, error) error) (int, error)
+	PrefixForeach(prefix []byte, fn func([]byte, []byte, error) error) error
 	Foreach(fn func([]byte, []byte, error) error) error
 	IsExist([]byte) (bool, error)
 

--- a/internal/pkg/storage/storage_browser.go
+++ b/internal/pkg/storage/storage_browser.go
@@ -149,11 +149,11 @@ func (s *QSIndexDB) PrefixDelete(prefix []byte) (int, error) {
 
 	kRange, err := idb.NewKeyRangeLowerBound(BytesToArrayBuffer(prefix), false)
 	if err != nil {
-		return err
+		return matched, err
 	}
 	cursorRequest, err := store.OpenKeyCursorRange(kRange, idb.CursorNext)
 	if err != nil {
-		return err
+		return matched, err
 	}
 	err = cursorRequest.Iter(s.ctx, func(cursor *idb.Cursor) error {
 		key, err := cursor.Key()
@@ -173,7 +173,7 @@ func (s *QSIndexDB) PrefixDelete(prefix []byte) (int, error) {
 	})
 
 	if err != nil {
-		return err
+		return matched, err
 	}
 
 	err = txn.Await(s.ctx)
@@ -186,11 +186,11 @@ func (s *QSIndexDB) PrefixCondDelete(prefix []byte, fn func(k []byte, v []byte, 
 	matched := 0
 	kRange, err := idb.NewKeyRangeLowerBound(BytesToArrayBuffer(prefix), false)
 	if err != nil {
-		return err
+		return matched, err
 	}
 	cursorRequest, err := store.OpenCursorRange(kRange, idb.CursorNext)
 	if err != nil {
-		return err
+		return matched, err
 	}
 
 	err = cursorRequest.Iter(s.ctx, func(cursor *idb.CursorWithValue) error {
@@ -274,7 +274,7 @@ func (s *QSIndexDB) PrefixForeachKey(prefix []byte, valid []byte, reverse bool, 
 		}
 		cursorRequest, err := store.OpenKeyCursorRange(kRange, idb.CursorNext)
 		if err != nil {
-			return matched, derr
+			return matched, err
 		}
 		err = cursorRequest.Iter(s.ctx, func(cursor *idb.Cursor) error {
 			key, err := cursor.Key()

--- a/internal/pkg/storage/storage_native.go
+++ b/internal/pkg/storage/storage_native.go
@@ -30,16 +30,17 @@ func (s *QSBadger) Init(path string) error {
 	}
 
 	// enable compaction
-	go dbGC(s.db)
+	go dbGC(s.db, path)
 	return nil
 }
 
-func dbGC(db *badger.DB) {
+func dbGC(db *badger.DB, path string) {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 	for range ticker.C {
 	again:
-		err := db.RunValueLogGC(0.7)
+		err := db.RunValueLogGC(0.5)
+		dbmgr_log.Debugf("badger db %s GC finished, err: %s", path, err.Error())
 		if err == nil {
 			goto again
 		}

--- a/pkg/wasm/test.go
+++ b/pkg/wasm/test.go
@@ -69,7 +69,7 @@ func IndexDBTest() {
 
 		rKey, _ := orderedcode.Append(nil, keyPrefix, "-", orderedcode.Infinity, uint64(100))
 		i = 0
-		err = dbMgr.PrefixForeachKey(rKey, []byte(keyPrefix), true, func(k []byte, err error) error {
+		_, err = dbMgr.PrefixForeachKey(rKey, []byte(keyPrefix), true, func(k []byte, err error) error {
 			i += 1
 			curKey, _ := orderedcode.Append(nil, keyPrefix, "-", orderedcode.Infinity, uint64(100-i))
 			if !bytes.Equal(k, curKey) {
@@ -82,7 +82,7 @@ func IndexDBTest() {
 		}
 
 		i = 0
-		err = dbMgr.PrefixForeachKey([]byte(keyPrefix), []byte(keyPrefix), false, func(k []byte, err error) error {
+		_, err = dbMgr.PrefixForeachKey([]byte(keyPrefix), []byte(keyPrefix), false, func(k []byte, err error) error {
 			curKey, _ := orderedcode.Append(nil, keyPrefix, "-", orderedcode.Infinity, uint64(i))
 			i += 1
 			if !bytes.Equal(k, curKey) {


### PR DESCRIPTION
1. Return deleted count for `delete` related operations
    Followng interfaces are included

  ```
  PrefixDelete(prefix []byte) (int, error)
  PrefixCondDelete(prefix []byte, fn func(k []byte, v []byte, err error) (bool, error)) (int, error)
  PrefixForeachKey(prefix []byte, valid []byte, reverse bool, fn func([]byte, error) error) (int, error)
  ```

2. Add more debuging logs when do group data cleaning
3. Add a 5-min GC operation for badger db. Due to badger's underlying data structure, delete operation actually will not free disk space, we have to call `db.RunValueLogGC` to trigger a value log garbage collection.

