### PR TITLE
allow to put any json object in trx.Data instead of quorumpb.Object

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,17 +71,15 @@ func initConfig() {
 	}
 
 	logging.SetAllLoggers(lvl)
-	if !isDebug {
-		logging.SetLogLevel("swarm2", "error")
-		logging.SetLogLevel("basichost", "error")
-		logging.SetLogLevel("dht", "error")
-		logging.SetLogLevel("net/identify", "error")
-		logging.SetLogLevel("pubsub", "error")
-		logging.SetLogLevel("dht", "error")
-		logging.SetLogLevel("dht/RtRefreshManager", "error")
-		logging.SetLogLevel("reuseport-transport", "error")
-		logging.SetLogLevel("upgrader", "error")
-	}
+	logging.SetLogLevel("swarm2", "error")
+	logging.SetLogLevel("basichost", "error")
+	logging.SetLogLevel("dht", "error")
+	logging.SetLogLevel("net/identify", "error")
+	logging.SetLogLevel("pubsub", "error")
+	logging.SetLogLevel("dht", "error")
+	logging.SetLogLevel("dht/RtRefreshManager", "error")
+	logging.SetLogLevel("reuseport-transport", "error")
+	logging.SetLogLevel("upgrader", "error")
 
 	if logFile != "" {
 		w := zapcore.AddSync(&lumberjack.Logger{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,19 @@ func initConfig() {
 	if err != nil {
 		logger.Fatal(err)
 	}
+
 	logging.SetAllLoggers(lvl)
+	if !isDebug {
+		logging.SetLogLevel("swarm2", "error")
+		logging.SetLogLevel("basichost", "error")
+		logging.SetLogLevel("dht", "error")
+		logging.SetLogLevel("net/identify", "error")
+		logging.SetLogLevel("pubsub", "error")
+		logging.SetLogLevel("dht", "error")
+		logging.SetLogLevel("dht/RtRefreshManager", "error")
+		logging.SetLogLevel("reuseport-transport", "error")
+		logging.SetLogLevel("upgrader", "error")
+	}
 
 	if logFile != "" {
 		w := zapcore.AddSync(&lumberjack.Logger{

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/huo-ju/quercus v0.0.0-20210909192534-3740345b9ab8
 	github.com/ipfs/go-ipfs-util v0.0.2
 	github.com/ipfs/go-log/v2 v2.5.1
+	github.com/klauspost/compress v1.15.14
 	github.com/labstack/echo/v4 v4.7.2
 	github.com/labstack/gommon v0.3.1
 	github.com/libp2p/go-libp2p v0.23.2
@@ -63,6 +64,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
 	github.com/swaggo/echo-swagger v1.1.0
+	github.com/swaggo/swag v1.8.1
 	go.uber.org/zap v1.23.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
@@ -129,7 +131,6 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/klauspost/compress v1.15.10 // indirect
 	github.com/klauspost/cpuid/v2 v2.1.1 // indirect
 	github.com/koron/go-ssdp v0.0.3 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
@@ -195,7 +196,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.0 // indirect
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14 // indirect
-	github.com/swaggo/swag v1.8.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -569,8 +569,9 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.10 h1:Ai8UzuomSCDw90e1qNMtb15msBXsNpH6gzkkENQNcJo=
 github.com/klauspost/compress v1.15.10/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.15.14 h1:i7WCKDToww0wA+9qrUZ1xOjp218vfFo3nTU6UHp+gOc=
+github.com/klauspost/compress v1.15.14/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/internal/pkg/chainsdk/core/chain.go
+++ b/internal/pkg/chainsdk/core/chain.go
@@ -1,12 +1,12 @@
 package chain
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/network"
-	localcrypto "github.com/rumsystem/quorum/pkg/crypto"
 	chaindef "github.com/rumsystem/quorum/internal/pkg/chainsdk/def"
 	"github.com/rumsystem/quorum/internal/pkg/conn"
 	"github.com/rumsystem/quorum/internal/pkg/logging"
@@ -14,6 +14,7 @@ import (
 	"github.com/rumsystem/quorum/internal/pkg/utils"
 	"github.com/rumsystem/quorum/pkg/consensus"
 	"github.com/rumsystem/quorum/pkg/consensus/def"
+	localcrypto "github.com/rumsystem/quorum/pkg/crypto"
 	rumchaindata "github.com/rumsystem/quorum/pkg/data"
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
 	"google.golang.org/protobuf/proto"
@@ -843,9 +844,9 @@ func (chain *Chain) StopSnapshot() {
 	}
 }
 
-func (chain *Chain) GetNextNouce(groupId string, prefix ...string) (nonce uint64, err error) {
+func (chain *Chain) GetNextNonce(groupId string, prefix ...string) (nonce uint64, err error) {
 	nodeprefix := utils.GetPrefix(prefix...)
-	n, err := nodectx.GetDbMgr().GetNextNouce(groupId, nodeprefix)
+	n, err := nodectx.GetDbMgr().GetNextNonce(groupId, nodeprefix)
 	return n, err
 }
 
@@ -991,6 +992,7 @@ func (chain *Chain) ApplyProducerTrxs(trxs []*quorumpb.Trx, nodename string) err
 
 			decryptData, err := localcrypto.AesDecode(trx.Data, ciperKey)
 			if err != nil {
+				chain_log.Debugf("localcrypto.AesDecode trx.Data failed: %s, base64 encoded trx.Data: %s", err, base64.StdEncoding.EncodeToString(trx.Data))
 				return err
 			}
 
@@ -1042,7 +1044,7 @@ func (chain *Chain) ApplyProducerTrxs(trxs []*quorumpb.Trx, nodename string) err
 	return nil
 }
 
-//addBlock for producer
+// addBlock for producer
 func (chain *Chain) AddBlock(block *quorumpb.Block) error {
 	chain_log.Debugf("<%s> AddBlock called", chain.groupId)
 

--- a/internal/pkg/chainsdk/core/group.go
+++ b/internal/pkg/chainsdk/core/group.go
@@ -5,13 +5,12 @@ import (
 	"encoding/hex"
 	"time"
 
-	localcrypto "github.com/rumsystem/quorum/pkg/crypto"
 	"github.com/rumsystem/quorum/internal/pkg/conn"
 	"github.com/rumsystem/quorum/internal/pkg/logging"
 	"github.com/rumsystem/quorum/internal/pkg/nodectx"
 	"github.com/rumsystem/quorum/internal/pkg/storage/def"
+	localcrypto "github.com/rumsystem/quorum/pkg/crypto"
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
-	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -229,7 +228,7 @@ func (grp *Group) UpdAnnounce(item *quorumpb.AnnounceItem) (string, error) {
 	return grp.sendTrx(trx, conn.ProducerChannel)
 }
 
-func (grp *Group) PostToGroup(content proto.Message) (string, error) {
+func (grp *Group) PostToGroup(content []byte) (string, error) {
 	group_log.Debugf("<%s> PostToGroup called", grp.Item.GroupId)
 	if grp.Item.EncryptType == quorumpb.GroupEncryptType_PRIVATE {
 		keys, err := grp.ChainCtx.GetUsesEncryptPubKeys()
@@ -243,6 +242,7 @@ func (grp *Group) PostToGroup(content proto.Message) (string, error) {
 		}
 		return grp.sendTrx(trx, conn.ProducerChannel)
 	}
+
 	trx, err := grp.ChainCtx.GetTrxFactory().GetPostAnyTrx("", content)
 	if err != nil {
 		return "", err

--- a/internal/pkg/chainsdk/core/molassessnapshotsender.go
+++ b/internal/pkg/chainsdk/core/molassessnapshotsender.go
@@ -125,7 +125,7 @@ func (sssender *MolassesSnapshotSender) sendSnapshot() error {
 		snapshotpackage = &quorumpb.Snapshot{}
 		snapshotpackage.SnapshotId = guuid.NewString()
 		snapshotpackage.GroupId = sssender.groupId
-		nonce, err := nodectx.GetDbMgr().GetNextNouce(sssender.groupId, sssender.nodename)
+		nonce, err := nodectx.GetDbMgr().GetNextNonce(sssender.groupId, sssender.nodename)
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func (sssender *MolassesSnapshotSender) sendSnapshot() error {
 		item.SnapshotPackageId = snapshotPackageId
 
 		//for a bundle of snapshots, use same nonce
-		nonce, err := nodectx.GetDbMgr().GetNextNouce(sssender.groupId, sssender.nodename)
+		nonce, err := nodectx.GetDbMgr().GetNextNonce(sssender.groupId, sssender.nodename)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/chainsdk/def/trxfactory.go
+++ b/internal/pkg/chainsdk/def/trxfactory.go
@@ -2,7 +2,6 @@ package def
 
 import (
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
-	"google.golang.org/protobuf/proto"
 )
 
 type TrxFactoryIface interface {
@@ -13,7 +12,7 @@ type TrxFactoryIface interface {
 	GetRegProducerTrx(keyalias string, item *quorumpb.ProducerItem) (*quorumpb.Trx, error)
 	GetUpdAppConfigTrx(keyalias string, item *quorumpb.AppConfigItem) (*quorumpb.Trx, error)
 	GetRegUserTrx(keyalias string, item *quorumpb.UserItem) (*quorumpb.Trx, error)
-	GetPostAnyTrx(keyalias string, content proto.Message, encryptto ...[]string) (*quorumpb.Trx, error)
+	GetPostAnyTrx(keyalias string, content []byte, encryptto ...[]string) (*quorumpb.Trx, error)
 	GetReqBlockForwardTrx(keyalias string, block *quorumpb.Block) (*quorumpb.Trx, error)
 	GetReqBlockBackwardTrx(keyalias string, block *quorumpb.Block) (*quorumpb.Trx, error)
 }

--- a/internal/pkg/storage/chain/trxdb.go
+++ b/internal/pkg/storage/chain/trxdb.go
@@ -3,16 +3,28 @@ package chainstorage
 import (
 	"fmt"
 
-	localcrypto "github.com/rumsystem/quorum/pkg/crypto"
+	"github.com/rumsystem/quorum/internal/pkg/logging"
 	s "github.com/rumsystem/quorum/internal/pkg/storage"
 	"github.com/rumsystem/quorum/internal/pkg/storage/def"
 	"github.com/rumsystem/quorum/internal/pkg/utils"
+	localcrypto "github.com/rumsystem/quorum/pkg/crypto"
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
 	"google.golang.org/protobuf/proto"
 )
 
-//save trx
+var logger = logging.Logger("chainstorage")
+
+// save trx
 func (cs *Storage) AddTrx(trx *quorumpb.Trx, prefix ...string) error {
+	// compress trx.Data
+	/*
+		compressedContent := new(bytes.Buffer)
+		if err := utils.Compress(bytes.NewReader(trx.Data), compressedContent); err != nil {
+			return err
+		}
+		trx.Data = compressedContent.Bytes()
+	*/
+
 	nodeprefix := utils.GetPrefix(prefix...)
 	key := nodeprefix + s.TRX_PREFIX + "_" + trx.TrxId + "_" + fmt.Sprint(trx.Nonce)
 	value, err := proto.Marshal(trx)
@@ -27,7 +39,7 @@ func (cs *Storage) UpdTrx(trx *quorumpb.Trx, prefix ...string) error {
 	return cs.AddTrx(trx, prefix...)
 }
 
-//Get Trx
+// Get Trx
 func (cs *Storage) GetTrx(trxId string, storagetype def.TrxStorageType, prefix ...string) (t *quorumpb.Trx, n []int64, err error) {
 	nodeprefix := utils.GetPrefix(prefix...)
 	var trx quorumpb.Trx
@@ -38,10 +50,12 @@ func (cs *Storage) GetTrx(trxId string, storagetype def.TrxStorageType, prefix .
 		key = nodeprefix + s.TRX_PREFIX + "_" + trxId
 		err = cs.dbmgr.Db.PrefixForeach([]byte(key), func(k []byte, v []byte, err error) error {
 			if err != nil {
+				logger.Errorf("cs.dbmgr.Db.PrefixForeach failed: %s", err)
 				return err
 			}
 			perr := proto.Unmarshal(v, &trx)
 			if perr != nil {
+				logger.Errorf("proto.Unmarshal trx failed: %s", perr)
 				return perr
 			}
 			nonces = append(nonces, trx.Nonce)
@@ -52,11 +66,13 @@ func (cs *Storage) GetTrx(trxId string, storagetype def.TrxStorageType, prefix .
 		key = nodeprefix + s.CHD_PREFIX + "_" + s.BLK_PREFIX
 		err = cs.dbmgr.Db.PrefixForeach([]byte(key), func(k []byte, v []byte, err error) error {
 			if err != nil {
+				logger.Errorf("cs.dbmgr.Db.PrefixForeach failed: %s", err)
 				return err
 			}
 			chunk := quorumpb.BlockDbChunk{}
 			perr := proto.Unmarshal(v, &chunk)
 			if perr != nil {
+				logger.Errorf("proto.Unmarshal chunk failed: %s", err)
 				return perr
 			}
 			if chunk.BlockItem != nil && chunk.BlockItem.Trxs != nil {
@@ -67,6 +83,7 @@ func (cs *Storage) GetTrx(trxId string, storagetype def.TrxStorageType, prefix .
 						clonedtrxbuff, _ := proto.Marshal(blocktrx)
 						perr = proto.Unmarshal(clonedtrxbuff, &trx)
 						if perr != nil {
+							logger.Errorf("proto.Unmarshal clonedtrxbuff failed: %s", err)
 							return perr
 						}
 						trx.StorageType = quorumpb.TrxStroageType_CACHE
@@ -82,6 +99,17 @@ func (cs *Storage) GetTrx(trxId string, storagetype def.TrxStorageType, prefix .
 
 	pk, _ := localcrypto.Libp2pPubkeyToEthBase64(trx.SenderPubkey)
 	trx.SenderPubkey = pk
+
+	// decompress
+	/*
+		content := new(bytes.Buffer)
+		if err := utils.Decompress(bytes.NewReader(trx.Data), content); err != nil {
+			logger.Errorf("utils.Decompress failed: %s", err)
+			return nil, nil, err
+		}
+		trx.Data = content.Bytes()
+	*/
+
 	return &trx, nonces, err
 }
 

--- a/internal/pkg/storage/chain/trxdb.go
+++ b/internal/pkg/storage/chain/trxdb.go
@@ -1,6 +1,7 @@
 package chainstorage
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/rumsystem/quorum/internal/pkg/logging"
@@ -17,13 +18,11 @@ var logger = logging.Logger("chainstorage")
 // save trx
 func (cs *Storage) AddTrx(trx *quorumpb.Trx, prefix ...string) error {
 	// compress trx.Data
-	/*
-		compressedContent := new(bytes.Buffer)
-		if err := utils.Compress(bytes.NewReader(trx.Data), compressedContent); err != nil {
-			return err
-		}
-		trx.Data = compressedContent.Bytes()
-	*/
+	compressedContent := new(bytes.Buffer)
+	if err := utils.Compress(bytes.NewReader(trx.Data), compressedContent); err != nil {
+		return err
+	}
+	trx.Data = compressedContent.Bytes()
 
 	nodeprefix := utils.GetPrefix(prefix...)
 	key := nodeprefix + s.TRX_PREFIX + "_" + trx.TrxId + "_" + fmt.Sprint(trx.Nonce)
@@ -101,14 +100,12 @@ func (cs *Storage) GetTrx(trxId string, storagetype def.TrxStorageType, prefix .
 	trx.SenderPubkey = pk
 
 	// decompress
-	/*
-		content := new(bytes.Buffer)
-		if err := utils.Decompress(bytes.NewReader(trx.Data), content); err != nil {
-			logger.Errorf("utils.Decompress failed: %s", err)
-			return nil, nil, err
-		}
-		trx.Data = content.Bytes()
-	*/
+	content := new(bytes.Buffer)
+	if err := utils.Decompress(bytes.NewReader(trx.Data), content); err != nil {
+		logger.Errorf("utils.Decompress failed: %s", err)
+		return nil, nil, err
+	}
+	trx.Data = content.Bytes()
 
 	return &trx, nonces, err
 }

--- a/internal/pkg/storage/dbmgr.go
+++ b/internal/pkg/storage/dbmgr.go
@@ -239,7 +239,7 @@ func (dbMgr *DbMgr) GetAnnouncedEncryptKeys(groupId string, prefix ...string) (p
 }
 
 //get next nonce
-func (dbMgr *DbMgr) GetNextNouce(groupId string, prefix ...string) (uint64, error) {
+func (dbMgr *DbMgr) GetNextNonce(groupId string, prefix ...string) (uint64, error) {
 	nodeprefix := utils.GetPrefix(prefix...)
 	key := nodeprefix + NONCE_PREFIX + "_" + groupId
 

--- a/internal/pkg/utils/compress.go
+++ b/internal/pkg/utils/compress.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// Compress compress with zstd
+func Compress(in io.Reader, out io.Writer) error {
+	enc, err := zstd.NewWriter(out)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(enc, in)
+	if err != nil {
+		enc.Close()
+		return err
+	}
+
+	return enc.Close()
+}
+
+// Decompress decompress with zstd
+func Decompress(in io.Reader, out io.Writer) error {
+	d, err := zstd.NewReader(in)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	_, err = io.Copy(out, d)
+
+	return err
+}

--- a/pkg/chainapi/api/announcesdk.go
+++ b/pkg/chainapi/api/announcesdk.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"encoding/hex"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	chain "github.com/rumsystem/quorum/internal/pkg/chainsdk/core"
+	rumerrors "github.com/rumsystem/quorum/internal/pkg/errors"
+	"github.com/rumsystem/quorum/internal/pkg/utils"
+	"github.com/rumsystem/quorum/pkg/chainapi/handlers"
+	localcrypto "github.com/rumsystem/quorum/pkg/crypto"
+	quorumpb "github.com/rumsystem/quorum/pkg/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+type (
+	AnnounceNodeSDKParam struct {
+		GroupId string `param:"group_id" json:"-" validate:"required"`
+		Req     []byte `json:"Req" validate:"required" swaggertype:"primitive,string"` // base64 encoded req
+	}
+)
+
+// @Tags LightNode
+// @Summary AnnounceUserPubkey
+// @Description Announce User's encryption Pubkey to the group for light node
+// @Accept json
+// @Produce json
+// @Param data body AnnounceNodeSDKParam true "AnnounceParam"
+// @Success 200 {object} handlers.AnnounceResult
+// @Router /api/v1/node/announce/{group_id} [post]
+func (h *Handler) AnnounceNodeSDK(c echo.Context) (err error) {
+	cc := c.(*utils.CustomContext)
+	params := new(AnnounceNodeSDKParam)
+	if err := cc.BindAndValidate(params); err != nil {
+		return err
+	}
+
+	groupmgr := chain.GetGroupMgr()
+	group, ok := groupmgr.Groups[params.GroupId]
+	if !ok {
+		return rumerrors.NewBadRequestError("INVALID_GROUP")
+	}
+
+	ciperKey, err := hex.DecodeString(group.Item.CipherKey)
+	if err != nil {
+		return rumerrors.NewBadRequestError("CHAINSDK_INTERNAL_ERROR")
+	}
+
+	decryptData, err := localcrypto.AesDecode(params.Req, ciperKey)
+	if err != nil {
+		return rumerrors.NewBadRequestError("DECRYPT_DATA_FAILED")
+	}
+
+	var item quorumpb.AnnounceItem
+	if err := proto.Unmarshal(decryptData, &item); err != nil {
+		return rumerrors.NewBadRequestError("Req is not quorumpb.AnnounceItem object")
+	}
+
+	trxId, err := group.UpdAnnounce(&item)
+	if err != nil {
+		return err
+	}
+	var result *handlers.AnnounceResult
+	result = &handlers.AnnounceResult{
+		GroupId:                item.GroupId,
+		AnnouncedSignPubkey:    item.SignPubkey,
+		AnnouncedEncryptPubkey: item.EncryptPubkey,
+		Type:                   item.Type.String(),
+		Action:                 item.Action.String(),
+		Sign:                   item.AnnouncerSignature,
+		TrxId:                  trxId,
+	}
+
+	return c.JSON(http.StatusOK, result)
+}

--- a/pkg/chainapi/api/cleargroupdata_test.go
+++ b/pkg/chainapi/api/cleargroupdata_test.go
@@ -57,20 +57,16 @@ func TestClearGroup(t *testing.T) {
 	content := fmt.Sprintf("%s hello world", RandString(4))
 	name := fmt.Sprintf("%s post to group testing", RandString(4))
 	postGroupParam := PostGroupParam{
-		Type: "Add",
-		Object: PostObject{
-			Type:    "Note",
-			Content: content,
-			Name:    name,
+		Data: map[string]interface{}{
+			"type":    "Note",
+			"content": content,
+			"name":    name,
 		},
-		Target: PostTarget{
-			Type: "Group",
-			ID:   group.GroupId,
-		},
+		GroupID: group.GroupId,
 	}
 
 	if _, err := postToGroup(peerapi, postGroupParam); err != nil {
-		t.Errorf("postToGroup failed: %s, payload: %+v", err, postGroupParam)
+		t.Fatalf("postToGroup failed: %s, payload: %+v", err, postGroupParam)
 	}
 
 	if _, err := clearGroup(peerapi, handlers.ClearGroupDataParam{GroupId: group.GroupId}); err != nil {

--- a/pkg/chainapi/api/getchaintrxallowlist_test.go
+++ b/pkg/chainapi/api/getchaintrxallowlist_test.go
@@ -71,7 +71,7 @@ func TestUpdateChainAllowList(t *testing.T) {
 	}
 
 	// get allow list
-	time.Sleep(10 * time.Second)
+	time.Sleep(15 * time.Second)
 	rules, err := getGroupAllowList(peerapi, group.GroupId)
 	if err != nil {
 		t.Fatalf("getGroupAllowList failed: %s", err)

--- a/pkg/chainapi/api/getchaintrxdenylist_test.go
+++ b/pkg/chainapi/api/getchaintrxdenylist_test.go
@@ -71,7 +71,7 @@ func TestUpdateChainDenyList(t *testing.T) {
 	}
 
 	// get deny list
-	time.Sleep(10 * time.Second)
+	time.Sleep(15 * time.Second)
 	rules, err := getGroupDenyList(peerapi, group.GroupId)
 	if err != nil {
 		t.Fatalf("getGroupDenyList failed: %s", err)

--- a/pkg/chainapi/api/getcontentnsdk.go
+++ b/pkg/chainapi/api/getcontentnsdk.go
@@ -59,11 +59,6 @@ func (h *Handler) GetContentNSdk(c echo.Context) (err error) {
 		return rumerrors.NewBadRequestError(rumerrors.ErrGroupNotFound)
 	}
 
-	//private group is NOT supported
-	if group.Item.EncryptType == quorumpb.GroupEncryptType_PRIVATE {
-		return rumerrors.NewBadRequestError(rumerrors.ErrPrivateGroupNotSupported)
-	}
-
 	ciperKey, err := hex.DecodeString(group.Item.CipherKey)
 	if err != nil {
 		return rumerrors.NewBadRequestError(err)

--- a/pkg/chainapi/api/getgroupctn_test.go
+++ b/pkg/chainapi/api/getgroupctn_test.go
@@ -33,15 +33,11 @@ func TestGetGroupContent(t *testing.T) {
 	content := fmt.Sprintf("%s hello world", RandString(4))
 	name := fmt.Sprintf("%s post to group testing", RandString(4))
 	postGroupParam := PostGroupParam{
-		Type: "Add",
-		Object: PostObject{
-			Type:    "Note",
-			Content: content,
-			Name:    name,
-		},
-		Target: PostTarget{
-			Type: "Group",
-			ID:   group.GroupId,
+		GroupID: group.GroupId,
+		Data: map[string]interface{}{
+			"type":    "Note",
+			"content": content,
+			"name":    name,
 		},
 	}
 
@@ -54,7 +50,7 @@ func TestGetGroupContent(t *testing.T) {
 	}
 
 	// FIXME
-	time.Sleep(time.Second * 25)
+	time.Sleep(time.Second * 30)
 
 	// check peerapi received content
 	for _, api := range []string{peerapi, peerapi2} {

--- a/pkg/chainapi/api/gettrx_test.go
+++ b/pkg/chainapi/api/gettrx_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/rumsystem/quorum/pkg/chainapi/handlers"
-	"github.com/rumsystem/quorum/testnode"
 	"github.com/rumsystem/quorum/pkg/pb"
+	"github.com/rumsystem/quorum/testnode"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -54,16 +54,12 @@ func TestGetTrx(t *testing.T) {
 	content := fmt.Sprintf("%s hello world", RandString(4))
 	name := fmt.Sprintf("%s post to group testing", RandString(4))
 	postGroupParam := PostGroupParam{
-		Type: "Add",
-		Object: PostObject{
-			Type:    "Note",
-			Content: content,
-			Name:    name,
+		Data: map[string]interface{}{
+			"type":    "Note",
+			"content": content,
+			"name":    name,
 		},
-		Target: PostTarget{
-			Type: "Group",
-			ID:   group.GroupId,
-		},
+		GroupID: group.GroupId,
 	}
 
 	postResult, err := postToGroup(peerapi, postGroupParam)

--- a/pkg/chainapi/api/getuserencryptpubkeys.go
+++ b/pkg/chainapi/api/getuserencryptpubkeys.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	chain "github.com/rumsystem/quorum/internal/pkg/chainsdk/core"
+	rumerrors "github.com/rumsystem/quorum/internal/pkg/errors"
+	"github.com/rumsystem/quorum/internal/pkg/utils"
+)
+
+type (
+	GetUserEncryptPubKeysParam struct {
+		GroupId string `param:"group_id" json:"group_id" validate:"required" example:"78cbab65-17e7-49d2-892a-311cec77c120"`
+	}
+
+	GetUserEncryptPubKeysResult struct {
+		Keys []string `json:"keys" example:"age1gcd6v44ys4u72ljc543er65sj8qlscnwqp2nm4m9yg7zwcc0648q7swrka,age1fxfkenckddacqpm9ar3wvyg4ek32p9d7rlyz28y4catzfhjw4ggs8fvdl5"`
+	}
+)
+
+// @Tags LightNode
+// @Summary GetUserEncryptPubKeys
+// @Description get user encrypt pub keys
+// @Accept  json
+// @Produce json
+// @Param   group_id path string true "Group Id"
+// @Success 200 {object} interface{}
+// @Router  /api/v1/node/getuserencryptpubkeys/{group_id} [get]
+func (h *Handler) GetUserEncryptPubKeys(c echo.Context) (err error) {
+	cc := c.(*utils.CustomContext)
+	param := GetUserEncryptPubKeysParam{}
+	if err := cc.BindAndValidate(&param); err != nil {
+		return err
+	}
+	groupmgr := chain.GetGroupMgr()
+	group, ok := groupmgr.Groups[param.GroupId]
+	if !ok {
+		return rumerrors.NewBadRequestError("INVALID_GROUP")
+	}
+
+	keys, err := group.ChainCtx.GetUsesEncryptPubKeys()
+	if err != nil {
+		return err
+	}
+
+	result := GetUserEncryptPubKeysResult{Keys: keys}
+	return c.JSON(http.StatusOK, result)
+}

--- a/pkg/chainapi/api/group_test.go
+++ b/pkg/chainapi/api/group_test.go
@@ -144,21 +144,9 @@ func isInGroup(api string, groupID string) (bool, error) {
 	return false, nil
 }
 
-type PostObject struct {
-	Type    string `json:"type" validate:"required"`
-	Content string `json:"content" validate:"required"`
-	Name    string `json:"name" validate:"required"`
-}
-
-type PostTarget struct {
-	Type string `json:"type" validate:"required"`
-	ID   string `json:"id" validate:"required"`
-}
-
 type PostGroupParam struct {
-	Type   string     `json:"type" validate:"required"`
-	Object PostObject `json:"object" validate:"required"`
-	Target PostTarget `json:"target" validate:"required"`
+	GroupID string                 `json:"group_id" validate:"required"`
+	Data    map[string]interface{} `json:"data" validate:"required"`
 }
 
 func postToGroup(api string, payload PostGroupParam) (*handlers.TrxResult, error) {
@@ -167,7 +155,8 @@ func postToGroup(api string, payload PostGroupParam) (*handlers.TrxResult, error
 		return nil, err
 	}
 	payloadStr := string(payloadByte[:])
-	_, resp, err := testnode.RequestAPI(api, "/api/v1/group/content", "POST", payloadStr)
+	path := fmt.Sprintf("/api/v1/group/%s/content", payload.GroupID)
+	_, resp, err := testnode.RequestAPI(api, path, "POST", payloadStr)
 	if err != nil {
 		return nil, err
 	}
@@ -188,26 +177,17 @@ func postToGroup(api string, payload PostGroupParam) (*handlers.TrxResult, error
 	return &result, nil
 }
 
-type ContentInnerStruct struct {
-	Type    string `json:"type" validate:"required"`
-	Content string `json:"content" validate:"required"`
-	Name    string `json:"name" validate:"required"`
-}
-
 type GroupContentItem struct {
-	TrxId     string             `json:"TrxId" validate:"required"`
-	Publisher string             `json:"Publisher" validate:"required"`
-	Content   ContentInnerStruct `json:"Content" validate:"required"`
-	TypeUrl   string             `json:"TypeUrl" validate:"required"`
-	TimeStamp int64              `json:"TimeStamp" validate:"required"`
+	TrxId     string                 `json:"TrxId" validate:"required"`
+	Publisher string                 `json:"Publisher" validate:"required"`
+	Content   map[string]interface{} `json:"Content" validate:"required"`
+	TimeStamp int64                  `json:"TimeStamp" validate:"required"`
 }
 
 func getGroupContent(api string, groupID string) ([]GroupContentItem, error) {
 
-	//curl -v -X POST -H 'Content-Type: application/json' -d '{"senders":[ "CAISIQP8dKlMcBXzqKrnQSDLiSGWH+bRsUCmzX42D9F41CPzag=="]}' "http://localhost:8002/app/api/v1/group/5a3224cc-40b0-4491-bfc7-9b76b85b5dd8/content?starttrx=95f74d77-b15a-4cf5-a964-1c367c1b1909&num=20"
-
 	urlSuffix := fmt.Sprintf("/app/api/v1/group/%s/content", groupID)
-	_, resp, err := testnode.RequestAPI(api, urlSuffix, "POST", "{\"senders\":[]}")
+	_, resp, err := testnode.RequestAPI(api, urlSuffix, "GET", "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chainapi/api/posttogroup.go
+++ b/pkg/chainapi/api/posttogroup.go
@@ -7,7 +7,6 @@ import (
 	rumerrors "github.com/rumsystem/quorum/internal/pkg/errors"
 	"github.com/rumsystem/quorum/internal/pkg/utils"
 	"github.com/rumsystem/quorum/pkg/chainapi/handlers"
-	quorumpb "github.com/rumsystem/quorum/pkg/pb"
 )
 
 // @Tags Groups
@@ -15,17 +14,18 @@ import (
 // @Description Post object to a group
 // @Accept json
 // @Produce json
-// @Param data body quorumpb.Activity true "Activity object"
+// @Param group_id path string  true "Group Id"
+// @Param data body handlers.PostToGroupParam true "payload"
 // @Success 200 {object} handlers.TrxResult
-// @Router /api/v1/group/content [post]
+// @Router /api/v1/group/{group_id}/content [post]
 func (h *Handler) PostToGroup(c echo.Context) (err error) {
 	cc := c.(*utils.CustomContext)
-	paramspb := new(quorumpb.Activity)
-	if err := cc.BindAndValidate(paramspb); err != nil {
+	payload := handlers.PostToGroupParam{}
+	if err := cc.BindAndValidate(&payload); err != nil {
 		return err
 	}
 
-	res, err := handlers.PostToGroup(paramspb)
+	res, err := handlers.PostToGroup(&payload)
 	if err != nil {
 		return rumerrors.NewBadRequestError(err)
 	}

--- a/pkg/chainapi/api/posttogroup_test.go
+++ b/pkg/chainapi/api/posttogroup_test.go
@@ -29,16 +29,12 @@ func TestPostToGroup(t *testing.T) {
 
 	// post to group
 	postGroupParam := PostGroupParam{
-		Type: "Add",
-		Object: PostObject{
-			Type:    "Note",
-			Content: "Hello World",
-			Name:    "post to group testing",
+		Data: map[string]interface{}{
+			"type":    "Note",
+			"content": "Hello World",
+			"name":    "post to group testing",
 		},
-		Target: PostTarget{
-			Type: "Group",
-			ID:   group.GroupId,
-		},
+		GroupID: group.GroupId,
 	}
 
 	postResult, err := postToGroup(peerapi, postGroupParam)

--- a/pkg/chainapi/api/sendtrx.go
+++ b/pkg/chainapi/api/sendtrx.go
@@ -60,11 +60,6 @@ func (h *Handler) SendTrx(c echo.Context) (err error) {
 		return rumerrors.NewBadRequestError(rumerrors.ErrGroupNotFound)
 	}
 
-	//private group is NOT supported
-	if group.Item.EncryptType == quorumpb.GroupEncryptType_PRIVATE {
-		return rumerrors.NewBadRequestError(rumerrors.ErrPrivateGroupNotSupported)
-	}
-
 	ciperKey, err := hex.DecodeString(group.Item.CipherKey)
 	if err != nil {
 		return rumerrors.NewBadRequestError(err)

--- a/pkg/chainapi/api/server.go
+++ b/pkg/chainapi/api/server.go
@@ -54,7 +54,7 @@ func StartAPIServer(config StartAPIParam, signalch chan os.Signal, h *Handler, a
 		r.POST("/v2/group/join", h.JoinGroupV2())
 		r.POST("/v1/group/leave", h.LeaveGroup)
 		r.POST("/v1/group/clear", h.ClearGroupData)
-		r.POST("/v1/group/content", h.PostToGroup)
+		r.POST("/v1/group/:group_id/content", h.PostToGroup)
 		r.POST("/v1/group/profile", h.UpdateProfile)
 		r.POST("/v1/network/peers", h.AddPeers)
 		if nodeopt.EnableRelay {
@@ -88,7 +88,7 @@ func StartAPIServer(config StartAPIParam, signalch chan os.Signal, h *Handler, a
 		r.GET("/v1/group/:group_id/appconfig/:key", h.GetAppConfigItem)
 		r.GET("/v1/group/:group_id/seed", h.GetGroupSeedHandler)
 		r.GET("/v1/group/:group_id/pubqueue", h.GetPubQueue)
-		a.POST("/v1/group/:group_id/content", apph.ContentByPeers)
+		a.GET("/v1/group/:group_id/content", apph.ContentByPeers)
 		a.POST("/v1/token/refresh", apph.RefreshToken)
 		a.POST("/v1/token/create", apph.CreateToken)
 

--- a/pkg/chainapi/api/server.go
+++ b/pkg/chainapi/api/server.go
@@ -106,6 +106,7 @@ func StartAPIServer(config StartAPIParam, signalch chan os.Signal, h *Handler, a
 		r.POST("/v1/node/trx/:group_id", h.SendTrx)
 		r.POST("/v1/node/groupctn/:group_id", h.GetContentNSdk)
 		r.POST("/v1/node/getchaindata/:group_id", h.GetDataNSdk)
+		r.GET("/v1/node/getencryptpubkeys/:group_id", h.GetUserEncryptPubKeys)
 
 	} else {
 		r.GET("/v1/node", h.GetBootstrapNodeInfo)

--- a/pkg/chainapi/api/server.go
+++ b/pkg/chainapi/api/server.go
@@ -107,6 +107,7 @@ func StartAPIServer(config StartAPIParam, signalch chan os.Signal, h *Handler, a
 		r.POST("/v1/node/groupctn/:group_id", h.GetContentNSdk)
 		r.POST("/v1/node/getchaindata/:group_id", h.GetDataNSdk)
 		r.GET("/v1/node/getencryptpubkeys/:group_id", h.GetUserEncryptPubKeys)
+		r.POST("/v1/node/announce/:group_id", h.AnnounceNodeSDK)
 
 	} else {
 		r.GET("/v1/node", h.GetBootstrapNodeInfo)

--- a/pkg/chainapi/api/updateprofile_test.go
+++ b/pkg/chainapi/api/updateprofile_test.go
@@ -27,6 +27,11 @@ type Person struct {
 	Wallet []*Payment `json:"wallet,omitempty"`
 }
 
+type PostTarget struct {
+	Type string `json:"type" validate:"required"`
+	ID   string `json:"id" validate:"required"`
+}
+
 type updateProfileParam struct {
 	Type   string     `json:"type" validate:"required,oneof=Update"`
 	Person Person     `json:"person" validate:"required"`

--- a/pkg/chainapi/appapi/content.go
+++ b/pkg/chainapi/appapi/content.go
@@ -2,6 +2,7 @@ package appapi
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -23,8 +24,8 @@ type GroupContentObjectItem struct {
 	        "name": "A simple Node id1"
 	    }
 	*/
-	Content   []byte
-	TimeStamp int64 `example:"1629748212762123400"`
+	Content   map[string]interface{} // json object
+	TimeStamp int64                  `example:"1629748212762123400"`
 }
 
 type SenderList struct {
@@ -111,8 +112,12 @@ func (h *Handler) ContentByPeers(c echo.Context) (err error) {
 			trx.Data = decryptData
 		}
 
+		var content map[string]interface{}
+		if err := json.Unmarshal(trx.Data, &content); err != nil {
+			return err
+		}
 		pk, _ := localcrypto.Libp2pPubkeyToEthBase64(trx.SenderPubkey)
-		ctnobjitem := &GroupContentObjectItem{TrxId: trx.TrxId, Publisher: pk, Content: trx.Data, TimeStamp: trx.TimeStamp}
+		ctnobjitem := &GroupContentObjectItem{TrxId: trx.TrxId, Publisher: pk, Content: content, TimeStamp: trx.TimeStamp}
 		ctnobjList = append(ctnobjList, ctnobjitem)
 	}
 	return c.JSON(http.StatusOK, ctnobjList)

--- a/pkg/chainapi/appapi/content.go
+++ b/pkg/chainapi/appapi/content.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rumsystem/quorum/internal/pkg/storage/def"
 	localcrypto "github.com/rumsystem/quorum/pkg/crypto"
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
-	"google.golang.org/protobuf/proto"
 )
 
 type GroupContentObjectItem struct {
@@ -24,9 +23,8 @@ type GroupContentObjectItem struct {
 	        "name": "A simple Node id1"
 	    }
 	*/
-	Content   proto.Message
-	TypeUrl   string `example:"quorum.pb.Object"`
-	TimeStamp int64  `example:"1629748212762123400"`
+	Content   []byte
+	TimeStamp int64 `example:"1629748212762123400"`
 }
 
 type SenderList struct {
@@ -45,7 +43,7 @@ type SenderList struct {
 // @Param nonce query int false "the nonce of trx, the default value is the latest"
 // @Param data body SenderList true "SenderList"
 // @Success 200 {array} GroupContentObjectItem
-// @Router /app/api/v1/group/{group_id}/content [post]
+// @Router /app/api/v1/group/{group_id}/content [get]
 func (h *Handler) ContentByPeers(c echo.Context) (err error) {
 	groupid := c.Param("group_id")
 	num, _ := strconv.Atoi(c.QueryParam("num"))
@@ -113,12 +111,8 @@ func (h *Handler) ContentByPeers(c echo.Context) (err error) {
 			trx.Data = decryptData
 		}
 
-		ctnobj, typeurl, errum := quorumpb.BytesToMessage(trx.TrxId, trx.Data)
-		if errum != nil {
-			c.Logger().Errorf("Unmarshal trx.Data %s Err: %s", trx.TrxId, errum)
-		}
 		pk, _ := localcrypto.Libp2pPubkeyToEthBase64(trx.SenderPubkey)
-		ctnobjitem := &GroupContentObjectItem{TrxId: trx.TrxId, Publisher: pk, Content: ctnobj, TimeStamp: trx.TimeStamp, TypeUrl: typeurl}
+		ctnobjitem := &GroupContentObjectItem{TrxId: trx.TrxId, Publisher: pk, Content: trx.Data, TimeStamp: trx.TimeStamp}
 		ctnobjList = append(ctnobjList, ctnobjitem)
 	}
 	return c.JSON(http.StatusOK, ctnobjList)

--- a/pkg/chainapi/handlers/posttogroup.go
+++ b/pkg/chainapi/handlers/posttogroup.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -20,7 +20,7 @@ type PostToGroupParam struct {
 		}
 	}
 	*/
-	Data string `json:"data" validate:"required"`
+	Data map[string]interface{} `json:"data" validate:"required"` // json object
 }
 
 type TrxResult struct {
@@ -28,15 +28,14 @@ type TrxResult struct {
 }
 
 func PostToGroup(payload *PostToGroupParam) (*TrxResult, error) {
-	data, err := base64.StdEncoding.DecodeString(payload.Data)
-	if err != nil {
-		return nil, err
-	}
-
 	groupmgr := chain.GetGroupMgr()
 	group, ok := groupmgr.Groups[payload.GroupId]
 	if !ok {
 		return nil, errors.New(fmt.Sprintf("Group %s not exist", payload.GroupId))
+	}
+	data, err := json.Marshal(payload.Data)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Invalid Data field, not json object, json.Marshal failed: %s", err))
 	}
 
 	trxId, err := group.PostToGroup(data)

--- a/pkg/chainapi/handlers/posttogroup.go
+++ b/pkg/chainapi/handlers/posttogroup.go
@@ -1,79 +1,47 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 
-	"github.com/go-playground/validator/v10"
 	chain "github.com/rumsystem/quorum/internal/pkg/chainsdk/core"
-	quorumpb "github.com/rumsystem/quorum/pkg/pb"
 )
 
-type CustomValidatorPost struct {
-	Validator *validator.Validate
-}
-
-func (cv *CustomValidatorPost) Validate(i interface{}) error {
-	switch i.(type) {
-	case *quorumpb.Activity:
-		inputobj := i.(*quorumpb.Activity)
-		if inputobj.Type == Add {
-			if inputobj.Object != nil && inputobj.Target != nil {
-				if inputobj.Target.Type == Group && inputobj.Target.Id != "" {
-					if inputobj.Object.Type == Note && (inputobj.Object.Content != "" || len(inputobj.Object.Image) > 0) {
-						return nil
-					} else if inputobj.Object.Type == File && inputobj.Object.File != nil {
-						return nil
-					}
-					return errors.New(fmt.Sprintf("unsupported object type: %s", inputobj.Object.Type))
-				}
-				return errors.New(fmt.Sprintf("Target Group must not be nil"))
-			}
-			return errors.New(fmt.Sprintf("Object and Target Object must not be nil"))
-		} else if inputobj.Type == Like || inputobj.Type == Dislike {
-			if inputobj.Object != nil && inputobj.Target != nil {
-				if inputobj.Target.Type == Group && inputobj.Target.Id != "" {
-					if inputobj.Object.Id != "" {
-						return nil
-					}
-					return errors.New(fmt.Sprintf("unsupported object type: %s", inputobj.Object.Type))
-				}
-				return errors.New(fmt.Sprintf("Target Group must not be nil"))
-			}
-			return errors.New(fmt.Sprintf("Object and Target Object must not be nil"))
-		}
-		return errors.New(fmt.Sprintf("unknown type of Actitity: %s", inputobj.Type))
-	default:
-		if err := cv.Validator.Struct(i); err != nil {
-			return err
+type PostToGroupParam struct {
+	GroupId string `param:"group_id" json:"group_id" validate:"required" example:"ac0eea7c-2f3c-4c67-80b3-136e46b924a8"`
+	/* Example:
+	{
+		"type": "Create",
+		"object": {
+			"type": "Note",
+			"id": 1,
+			"content": "hello world"
 		}
 	}
-	return nil
+	*/
+	Data string `json:"data" validate:"required"`
 }
 
 type TrxResult struct {
 	TrxId string `json:"trx_id" validate:"required" example:"9e54c173-c1dd-429d-91fa-a6b43c14da77"`
 }
 
-func PostToGroup(paramspb *quorumpb.Activity) (*TrxResult, error) {
-	validate := &CustomValidatorPost{Validator: validator.New()}
-	if err := validate.Validate(paramspb); err != nil {
+func PostToGroup(payload *PostToGroupParam) (*TrxResult, error) {
+	data, err := base64.StdEncoding.DecodeString(payload.Data)
+	if err != nil {
 		return nil, err
 	}
 
 	groupmgr := chain.GetGroupMgr()
-	if group, ok := groupmgr.Groups[paramspb.Target.Id]; ok {
-		if paramspb.Object.Type == "" {
-			paramspb.Object.Type = paramspb.Type
-		}
-
-		trxId, err := group.PostToGroup(paramspb.Object)
-
-		if err != nil {
-			return nil, err
-		}
-		return &TrxResult{trxId}, nil
-	} else {
-		return nil, errors.New(fmt.Sprintf("Group %s not exist", paramspb.Target.Id))
+	group, ok := groupmgr.Groups[payload.GroupId]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("Group %s not exist", payload.GroupId))
 	}
+
+	trxId, err := group.PostToGroup(data)
+	if err != nil {
+		return nil, err
+	}
+	return &TrxResult{trxId}, nil
 }

--- a/pkg/chainapi/handlers/updateprofile.go
+++ b/pkg/chainapi/handlers/updateprofile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	chain "github.com/rumsystem/quorum/internal/pkg/chainsdk/core"
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
+	"google.golang.org/protobuf/proto"
 )
 
 type CustomValidatorProfile struct {
@@ -70,7 +71,11 @@ func UpdateProfile(paramspb *quorumpb.Activity) (*UpdateProfileResult, error) {
 			}
 		}
 
-		trxId, err := group.PostToGroup(paramspb.Person)
+		content, err := proto.Marshal(paramspb.Person)
+		if err != nil {
+			return nil, err
+		}
+		trxId, err := group.PostToGroup(content)
 
 		if err != nil {
 			return nil, err

--- a/pkg/consensus/molassesuser.go
+++ b/pkg/consensus/molassesuser.go
@@ -177,7 +177,7 @@ func (user *MolassesUser) sendTrx(trx *quorumpb.Trx, channel conn.PsConnChanel) 
 	return trx.TrxId, nil
 }
 
-//resend all trx in the list
+// resend all trx in the list
 func (user *MolassesUser) resendTrx(trxs []*quorumpb.Trx) error {
 	molauser_log.Debugf("<%s> resendTrx called", user.groupId)
 	for _, trx := range trxs {
@@ -187,7 +187,7 @@ func (user *MolassesUser) resendTrx(trxs []*quorumpb.Trx) error {
 	return nil
 }
 
-//update resend count (+1) for all trxs
+// update resend count (+1) for all trxs
 func UpdateResendCount(trxs []*quorumpb.Trx) ([]*quorumpb.Trx, error) {
 	for _, trx := range trxs {
 		trx.ResendCount++

--- a/pkg/data/trx.go
+++ b/pkg/data/trx.go
@@ -47,11 +47,9 @@ func CreateTrxWithoutSign(nodename string, version string, groupItem *quorumpb.G
 			if err != nil {
 				return &trx, []byte(""), err
 			}
-
 		} else {
 			return &trx, []byte(""), fmt.Errorf("must have encrypt pubkeys for private group %s", groupItem.GroupId)
 		}
-
 	} else {
 		var err error
 		ciperKey, err := hex.DecodeString(groupItem.CipherKey)
@@ -96,8 +94,8 @@ func CreateTrxByEthKey(nodename string, version string, groupItem *quorumpb.Grou
 		return trx, err
 	}
 	trx.SenderSign = signature
-	return trx, nil
 
+	return trx, nil
 }
 
 // set TimeStamp and Expired for trx

--- a/pkg/data/trx_test.go
+++ b/pkg/data/trx_test.go
@@ -18,7 +18,7 @@ type TestNonce struct {
 	nonce uint64
 }
 
-func (tn *TestNonce) GetNextNouce(groupId string, prefix ...string) (nonce uint64, err error) {
+func (tn *TestNonce) GetNextNonce(groupId string, prefix ...string) (nonce uint64, err error) {
 	tn.nonce++
 	return tn.nonce, nil
 }

--- a/pkg/data/trxfactory.go
+++ b/pkg/data/trxfactory.go
@@ -3,6 +3,7 @@ package data
 import (
 	"encoding/binary"
 	"errors"
+
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
 	"google.golang.org/protobuf/proto"
 )
@@ -16,7 +17,7 @@ type TrxFactory struct {
 }
 
 type ChainNonce interface {
-	GetNextNouce(groupId string, prefix ...string) (nonce uint64, err error)
+	GetNextNonce(groupId string, prefix ...string) (nonce uint64, err error)
 }
 
 func (factory *TrxFactory) Init(version string, groupItem *quorumpb.GroupItem, nodename string, chainnonce ChainNonce) {
@@ -28,7 +29,7 @@ func (factory *TrxFactory) Init(version string, groupItem *quorumpb.GroupItem, n
 }
 
 func (factory *TrxFactory) CreateTrxByEthKey(msgType quorumpb.TrxType, data []byte, keyalias string, encryptto ...[]string) (*quorumpb.Trx, error) {
-	nonce, err := factory.chainNonce.GetNextNouce(factory.groupItem.GroupId, factory.nodename)
+	nonce, err := factory.chainNonce.GetNextNonce(factory.groupItem.GroupId, factory.nodename)
 	if err != nil {
 		return nil, err
 	}
@@ -146,16 +147,11 @@ func (factory *TrxFactory) GetBlockProducedTrx(keyalias string, blk *quorumpb.Bl
 	return CreateTrxByEthKey(factory.nodename, factory.version, factory.groupItem, quorumpb.TrxType_BLOCK_PRODUCED, int64(0), encodedcontent, keyalias)
 }
 
-func (factory *TrxFactory) GetPostAnyTrx(keyalias string, content proto.Message, encryptto ...[]string) (*quorumpb.Trx, error) {
-	encodedcontent, err := quorumpb.ContentToBytes(content)
-	if err != nil {
-		return nil, err
-	}
-
-	if binary.Size(encodedcontent) > OBJECT_SIZE_LIMIT {
+func (factory *TrxFactory) GetPostAnyTrx(keyalias string, content []byte, encryptto ...[]string) (*quorumpb.Trx, error) {
+	if binary.Size(content) > OBJECT_SIZE_LIMIT {
 		err := errors.New("Content size over 200Kb")
 		return nil, err
 	}
 
-	return factory.CreateTrxByEthKey(quorumpb.TrxType_POST, encodedcontent, keyalias, encryptto...)
+	return factory.CreateTrxByEthKey(quorumpb.TrxType_POST, content, keyalias, encryptto...)
 }

--- a/pkg/nodesdk/api/posttogroup.go
+++ b/pkg/nodesdk/api/posttogroup.go
@@ -9,8 +9,8 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	rumerrors "github.com/rumsystem/quorum/internal/pkg/errors"
-	nodesdkctx "github.com/rumsystem/quorum/pkg/nodesdk/nodesdkctx"
 	rumchaindata "github.com/rumsystem/quorum/pkg/data"
+	nodesdkctx "github.com/rumsystem/quorum/pkg/nodesdk/nodesdkctx"
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
 	"google.golang.org/protobuf/proto"
 )
@@ -91,7 +91,12 @@ func (h *NodeSDKHandler) PostToGroup() echo.HandlerFunc {
 			paramspb.Object.Type = paramspb.Type
 		}
 
-		trx, err := trxFactory.GetPostAnyTrx(nodesdkGroupItem.SignAlias, paramspb.Object)
+		data, err := proto.Marshal(paramspb.Object)
+		if err != nil {
+			return rumerrors.NewBadRequestError(err)
+		}
+
+		trx, err := trxFactory.GetPostAnyTrx(nodesdkGroupItem.SignAlias, data)
 		if err != nil {
 			return rumerrors.NewBadRequestError(err)
 		}

--- a/pkg/nodesdk/api/updprofile.go
+++ b/pkg/nodesdk/api/updprofile.go
@@ -12,8 +12,8 @@ import (
 	"github.com/labstack/echo/v4"
 	rumerrors "github.com/rumsystem/quorum/internal/pkg/errors"
 	"github.com/rumsystem/quorum/pkg/chainapi/handlers"
-	nodesdkctx "github.com/rumsystem/quorum/pkg/nodesdk/nodesdkctx"
 	rumchaindata "github.com/rumsystem/quorum/pkg/data"
+	nodesdkctx "github.com/rumsystem/quorum/pkg/nodesdk/nodesdkctx"
 	quorumpb "github.com/rumsystem/quorum/pkg/pb"
 	"google.golang.org/protobuf/proto"
 )
@@ -82,7 +82,12 @@ func (h *NodeSDKHandler) UpdProfile(c echo.Context) (err error) {
 	trxFactory := &rumchaindata.TrxFactory{}
 	trxFactory.Init(nodesdkctx.GetCtx().Version, nodesdkGroupItem.Group, nodesdkctx.GetCtx().Name, nodesdkctx.GetCtx())
 
-	trx, err := trxFactory.GetPostAnyTrx(nodesdkGroupItem.SignAlias, paramspb.Person)
+	data, err := proto.Marshal(paramspb.Person)
+	if err != nil {
+		return rumerrors.NewBadRequestError(err)
+	}
+
+	trx, err := trxFactory.GetPostAnyTrx(nodesdkGroupItem.SignAlias, data)
 	if err != nil {
 		return rumerrors.NewBadRequestError(err)
 	}

--- a/pkg/nodesdk/nodesdkctx/nodesdkctx.go
+++ b/pkg/nodesdk/nodesdkctx/nodesdkctx.go
@@ -54,8 +54,8 @@ func (ctx *NodeSdkCtx) GetChainStorage() *chainstorage.Storage {
 	return nodesdkCtx.chaindb
 }
 
-func (ctx *NodeSdkCtx) GetNextNouce(groupId string, prefix ...string) (nonce uint64, err error) {
-	n, err := dbMgr.GetNextNouce(groupId)
+func (ctx *NodeSdkCtx) GetNextNonce(groupId string, prefix ...string) (nonce uint64, err error) {
+	n, err := dbMgr.GetNextNonce(groupId)
 	return n, err
 }
 


### PR DESCRIPTION
- set some libp2p module log level to error
- update rest api route
  + POST /v1/group/content => POST /v1/group/:group_id/content
  + POST /v1/group/:group_id/content => GET /v1/group/:group_id/content
- allow to put any json object in trx.Data instead of quorumpb.Object